### PR TITLE
fix error if wmctrl is not installed

### DIFF
--- a/archey
+++ b/archey
@@ -470,9 +470,10 @@ class WindowManager:
             for key in wmDict.keys():
                 if key in processes:
                     wm = wmDict[key]
-                    break
+                else:
+                    wm = 'Not detected'
 
-        self.value = wm or 'Not detected'
+        self.value = wm
 
 
 class DesktopEnvironment:


### PR DESCRIPTION
If ```wmctrl``` is not installed, archey4 returns:
```bash
Traceback (most recent call last):
  File "./archey", line 615, in <module>
    output.append(key.name, key.value().value)
  File "./archey", line 475, in __init__
    self.value = wm or 'Not detected'
UnboundLocalError: local variable 'wm' referenced before assignment

```
This fixes the error by assigning "Not detected" in case ```wmctrl``` is not installed. 

It could be worth considering moving ```wmctrl``` to the list of required packages for ```archey4``` or using another method to determine the Windows Manager if this worka-round is sub-optimal.