### PR TITLE
Better LAN IP workaround

### DIFF
--- a/archey
+++ b/archey
@@ -825,7 +825,7 @@ class LAN_IP:
                 # Rather slow manual workaround for old `inetutils` versions, with `ip`
                 addresses = [check_output(
                         ['ip', 'route', 'get', '1.1.1.1'], stderr=DEVNULL
-                        ).decode().split()][6]
+                        ).decode().split()[6]]
             except:
                 addresses = []
         # Use list slice to save only `lan_ip_max_count` addresses.

--- a/archey
+++ b/archey
@@ -823,10 +823,9 @@ class LAN_IP:
         except (CalledProcessError, FileNotFoundError):
             try:
                 # Rather slow manual workaround for old `inetutils` versions, with `ip`
-                addresses = check_output(
+                addresses = [check_output(
                         ['ip', 'route', 'get', '1.1.1.1'], stderr=DEVNULL
-                        ).decode().split()
-                addresses = [addresses[6]]
+                        ).decode().split()][6]
             except:
                 addresses = []
         # Use list slice to save only `lan_ip_max_count` addresses.

--- a/archey
+++ b/archey
@@ -821,11 +821,14 @@ class LAN_IP:
                                      ).decode().split()
 
         except (CalledProcessError, FileNotFoundError):
-            # Slow manual workaround for old `inetutils` versions, with `ip`
-            addresses = check_output(
-                    ['ip', 'route', 'get', '1.1.1.1']
-                    ).decode().split()
-            addresses = [addresses[6]]
+            try:
+                # Rather slow manual workaround for old `inetutils` versions, with `ip`
+                addresses = check_output(
+                        ['ip', 'route', 'get', '1.1.1.1'], stderr=DEVNULL
+                        ).decode().split()
+                addresses = [addresses[6]]
+            except:
+                addresses = []
         # Use list slice to save only `lan_ip_max_count` addresses.
         # If set to `False`, don't modify the list.
         # This option is still optional.
@@ -848,6 +851,28 @@ class WAN_IP:
 
             except (FileNotFoundError, TimeoutExpired):
                 try:
+                # Workaround with ip to get the IPv6 address, faster than the
+                # original workaround
+                #ipv6_value = check_output(
+                #    ['tr', '-d', '" "'],
+                #    stdin=Popen(['xargs'],
+                #                stdout=PIPE,
+                #                stdin=Popen(['grep', '-oh', '"\w*:\w*"'],
+                #                            stdout=PIPE,
+                #                            stdin=Popen(['grep', '-E',
+                #                                         'scope (global|site)'
+                #                                         ], stdout=PIPE,
+                #                                        stdin=Popen(['ip',
+                #                                                     '-6',
+                #                                                     'addr',
+                #                                                     'show',
+                #                                                     'up'],
+                #                                                    stdout=PIPE
+                #                                                    ).stdout
+                #                                        ).stdout
+                #                            ).stdout
+                #                ).stdout
+                #    ).decode().split()
                     ipv6_value = check_output([
                         'wget', '-qO-', 'https://v6.ident.me/'
                         ], timeout=1).decode()

--- a/archey
+++ b/archey
@@ -823,26 +823,9 @@ class LAN_IP:
         except (CalledProcessError, FileNotFoundError):
             # Slow manual workaround for old `inetutils` versions, with `ip`
             addresses = check_output(
-                    ['cut', '-d', ' ', '-f', '4'],
-                    stdin=Popen(['cut', '-d', '/', '-f', '1'],
-                                stdout=PIPE,
-                                stdin=Popen(['tr', '-s', ' '],
-                                            stdout=PIPE,
-                                            stdin=Popen(['grep', '-E',
-                                                         'scope (global|site)'
-                                                         ], stdout=PIPE,
-                                                        stdin=Popen(['ip',
-                                                                     '-o',
-                                                                     'addr',
-                                                                     'show',
-                                                                     'up'],
-                                                                    stdout=PIPE
-                                                                    ).stdout
-                                                        ).stdout
-                                            ).stdout
-                                ).stdout
+                    ['ip', 'route', 'get', '1.1.1.1']
                     ).decode().split()
-
+            addresses = [addresses[6]]
         # Use list slice to save only `lan_ip_max_count` addresses.
         # If set to `False`, don't modify the list.
         # This option is still optional.

--- a/archey
+++ b/archey
@@ -850,28 +850,6 @@ class WAN_IP:
 
             except (FileNotFoundError, TimeoutExpired):
                 try:
-                # Workaround with ip to get the IPv6 address, faster than the
-                # original workaround
-                #ipv6_value = check_output(
-                #    ['tr', '-d', '" "'],
-                #    stdin=Popen(['xargs'],
-                #                stdout=PIPE,
-                #                stdin=Popen(['grep', '-oh', '"\w*:\w*"'],
-                #                            stdout=PIPE,
-                #                            stdin=Popen(['grep', '-E',
-                #                                         'scope (global|site)'
-                #                                         ], stdout=PIPE,
-                #                                        stdin=Popen(['ip',
-                #                                                     '-6',
-                #                                                     'addr',
-                #                                                     'show',
-                #                                                     'up'],
-                #                                                    stdout=PIPE
-                #                                                    ).stdout
-                #                                        ).stdout
-                #                            ).stdout
-                #                ).stdout
-                #    ).decode().split()
                     ipv6_value = check_output([
                         'wget', '-qO-', 'https://v6.ident.me/'
                         ], timeout=1).decode()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->


## Description
<!--- Describe your changes in detail -->
I replaced the long bulky LAN_IP workaround with a way shorter piece of code that is also a tiny
bit more efficient or at least as efficient as the current workaround. This uses `ip route get 1.1.1.1` and then grabs the 7th word from the output which is the PC's LAN IP. You can actually swap `1.1.1.1` for any other reliable IP address like `8.8.8.8`, so yeah. Here are two screenshots comparing my modified script (left) with the original script (right):

**Offline:**
![screen1](https://i.imgur.com/e7u7LoB.png)

**Online:**
![screen2](https://i.imgur.com/LklgiTE.png)

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
Why not :D

## How has this been tested ?
<!--- Include details of your testing environment here -->
Tested on my production laptop both on- and offline.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code improvement (non-breaking change which cleans up a piece of code)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [x] My change looks good ;
- [ ] I have updated the _README.md_ file accordingly ;
- [x] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
