### PR TITLE
Add config options for timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Below, some further explanations of each option available :
 		"char_before_unit": " ",
 		// Display temperature values in Fahrenheit instead of Celsius.
 		"use_fahrenheit": false
+	},
+	"timeout": {
+		// Some values you can adjust if the default ones look undersized for your system (seconds)
 	}
 }
 ```

--- a/archey
+++ b/archey
@@ -401,8 +401,8 @@ class Configuration():
                 'use_fahrenheit': False
             },
             'timeout': {
-                'ipv6_detection': 0.5,
-                'ipv4_detection': 0.5
+                'ipv4_detection': 1,
+                'ipv6_detection': 1
             }
         }
 

--- a/archey
+++ b/archey
@@ -399,6 +399,10 @@ class Configuration():
             'temperature': {
                 'char_before_unit': ' ',
                 'use_fahrenheit': False
+            },
+            'timeout': {
+                'ipv6_detection': 0.5,
+                'ipv4_detection': 0.5
             }
         }
 

--- a/archey
+++ b/archey
@@ -861,13 +861,15 @@ class WAN_IP:
                 ipv6_value = check_output([
                     'dig', '+short', '-6', 'aaaa', 'myip.opendns.com',
                     '@resolver1.ipv6-sandbox.opendns.com'
-                    ], timeout=config.get('timeout')['ipv6'], stderr=DEVNULL).decode().rstrip()
+                    ], timeout=config.get('timeout')['ipv6_detection'],
+                    stderr=DEVNULL).decode().rstrip()
 
             except (FileNotFoundError, TimeoutExpired):
                 try:
                     ipv6_value = check_output([
                         'wget', '-qO-', 'https://v6.ident.me/'
-                        ], timeout=config.get('timeout')['ipv6']).decode()
+                        ], timeout=config.get('timeout')['ipv6_detection']
+                        ).decode()
 
                 except (CalledProcessError, TimeoutExpired):
                     # It looks like this user doesn't have any IPv6 address...
@@ -881,13 +883,15 @@ class WAN_IP:
         try:
             ipv4_value = check_output([
                 'dig', '+short', 'myip.opendns.com', '@resolver1.opendns.com'
-                ], timeout=config.get('timeout')['ipv4'], stderr=DEVNULL).decode().rstrip()
+                ], timeout=config.get('timeout')['ipv4_detection'],
+                stderr=DEVNULL).decode().rstrip()
 
         except (FileNotFoundError, TimeoutExpired):
             try:
                 ipv4_value = check_output([
                     'wget', '-qO-', 'https://v4.ident.me/'
-                    ], timeout=config.get('timeout')['ipv4']).decode()
+                    ], timeout=config.get('timeout')['ipv4_detection']
+                    ).decode()
 
             except (CalledProcessError, TimeoutExpired):
                 # This user looks not connected to Internet...

--- a/archey
+++ b/archey
@@ -861,13 +861,13 @@ class WAN_IP:
                 ipv6_value = check_output([
                     'dig', '+short', '-6', 'aaaa', 'myip.opendns.com',
                     '@resolver1.ipv6-sandbox.opendns.com'
-                    ], timeout=0.5, stderr=DEVNULL).decode().rstrip()
+                    ], timeout=config.get('timeout')['ipv6'], stderr=DEVNULL).decode().rstrip()
 
             except (FileNotFoundError, TimeoutExpired):
                 try:
                     ipv6_value = check_output([
                         'wget', '-qO-', 'https://v6.ident.me/'
-                        ], timeout=1).decode()
+                        ], timeout=config.get('timeout')['ipv6']).decode()
 
                 except (CalledProcessError, TimeoutExpired):
                     # It looks like this user doesn't have any IPv6 address...
@@ -881,13 +881,13 @@ class WAN_IP:
         try:
             ipv4_value = check_output([
                 'dig', '+short', 'myip.opendns.com', '@resolver1.opendns.com'
-                ], timeout=0.5, stderr=DEVNULL).decode().rstrip()
+                ], timeout=config.get('timeout')['ipv4'], stderr=DEVNULL).decode().rstrip()
 
         except (FileNotFoundError, TimeoutExpired):
             try:
                 ipv4_value = check_output([
                     'wget', '-qO-', 'https://v4.ident.me/'
-                    ], timeout=1).decode()
+                    ], timeout=config.get('timeout')['ipv4']).decode()
 
             except (CalledProcessError, TimeoutExpired):
                 # This user looks not connected to Internet...

--- a/config.json
+++ b/config.json
@@ -36,7 +36,7 @@
 		"use_fahrenheit": false
 	},
 	"timeout": {
-		"ipv6_detection": 0.5,
-		"ipv4_detection": 0.5
+		"ipv4_detection": 1,
+		"ipv6_detection": 1
 	}
 }

--- a/config.json
+++ b/config.json
@@ -36,7 +36,7 @@
 		"use_fahrenheit": false
 	},
 	"timeout": {
-		"ipv6": 5.0,
-		"ipv4": 5.0
+		"ipv6_detection": 0.5,
+		"ipv4_detection": 0.5
 	}
 }

--- a/config.json
+++ b/config.json
@@ -34,5 +34,9 @@
 	"temperature": {
 		"char_before_unit": " ",
 		"use_fahrenheit": false
+	},
+	"timeout": {
+		"ipv6": 5.0,
+		"ipv4": 5.0
 	}
 }


### PR DESCRIPTION
 


## Description
Adds a timeout option to `config.json` and `archey`. Now the user can set the desired timeout time in their `config.json` file.


## Reason and / or context
For me, to get `WAN_IP` to populate successfully every time I run `archey` I required a timeout time (`timeout=5.0`) of `5.0`.


## How has this been tested ?
I tested this on my Arch Linux machine. Using timeout numbers like `0.5` `1` `1.0` all worked. 
Using timeout numbers like `.5` or `.any-valid-number` did **not** work.


## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] My change looks good ;
- [x] I have updated the _README.md_ file accordingly ;
- [X] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
