### PR TITLE
Adds `suppress_warnings` option to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ Below, some further explanations of each option available :
 	// If set to `false`, configurations defined afterwards won't be loaded.
 	// Developers running Archey from the original project may keep in there the original `config.json` while having their own external configuration set elsewhere.
 	"allow_overriding": true,
+	// If set to `true`, any execution warning or error would be hidden.
+	// It may not apply to configuration parsing warnings.
+	"suppress_warnings": false,
 	"entries": {
 		// Set to `false` each entry you want to mask.
 	},

--- a/archey
+++ b/archey
@@ -433,10 +433,16 @@ class Configuration():
 
             # If the user does not want any warning to appear : 2> /dev/null
             if config.get('suppress_warnings', False):
-                sys.stderr = open(os.devnull, 'w')
+                # One more if statement to avoid multiple `open` calls.
+                if sys.stderr == self._stderr:
+                    sys.stderr = open(os.devnull, 'w')
 
             else:
-                sys.stderr = self._stderr
+                # One more if statement to avoid useless assignments and...
+                # ... for closing previously opened new file descriptor.
+                if sys.stderr != self._stderr:
+                    sys.stderr.close()
+                    sys.stderr = self._stderr
 
         except FileNotFoundError:
             pass

--- a/archey
+++ b/archey
@@ -407,6 +407,9 @@ class Configuration():
             }
         }
 
+        # Let's "save" `STDERR` file descriptor for `suppress_warnings` option
+        self._stderr = sys.stderr
+
     def get(self, key, default=None):
         """
         A binding method to imitate the `dict.get()` behavior.
@@ -427,6 +430,13 @@ class Configuration():
         try:
             with open(path) as file:
                 self.updateRecursive(self.config, json.load(file))
+
+            # If the user does not want any warning to appear : 2> /dev/null
+            if config.get('suppress_warnings', False):
+                sys.stderr = open(os.devnull, 'w')
+
+            else:
+                sys.stderr = self._stderr
 
         except FileNotFoundError:
             pass

--- a/archey
+++ b/archey
@@ -410,6 +410,11 @@ class Configuration():
         # Let's "save" `STDERR` file descriptor for `suppress_warnings` option
         self._stderr = sys.stderr
 
+        # Now, let's load each optional configuration file in a "regular" order
+        self.loadConfiguration('/etc/archey4/')
+        self.loadConfiguration(os.path.expanduser('~') + '/.config/archey4/')
+        self.loadConfiguration(os.path.dirname(os.path.realpath(__file__)))
+
     def get(self, key, default=None):
         """
         A binding method to imitate the `dict.get()` behavior.
@@ -432,7 +437,7 @@ class Configuration():
                 self.updateRecursive(self.config, json.load(file))
 
             # If the user does not want any warning to appear : 2> /dev/null
-            if config.get('suppress_warnings', False):
+            if self.config.get('suppress_warnings', False):
                 # One more if statement to avoid multiple `open` calls.
                 if sys.stderr == self._stderr:
                     sys.stderr = open(os.devnull, 'w')
@@ -962,16 +967,14 @@ class Classes(Enum):
 
 # -------------- Main -------------- #
 
-if __name__ == '__main__':
-
-    # Load global and local configurations in a "regular" order (all optional)
-    config.loadConfiguration('/etc/archey4/')
-    config.loadConfiguration(os.path.expanduser('~') + '/.config/archey4/')
-    config.loadConfiguration(os.path.dirname(os.path.realpath(__file__)))
-
+def main():
     output = Output()
     for key in Classes:
         if config.get('entries', {}).get(key.name, True):
             output.append(key.name, key.value().value)
 
     output.output()
+
+
+if __name__ == '__main__':
+    main()

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
 	"allow_overriding": true,
+	"suppress_warnings": false,
 	"entries": {
 		"User": true,
 		"Hostname": true,


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Simply redirects `stderr` to `/dev/null` (or set it back to `STDERR` in function of `suppress_warning` configuration option value.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
May be useful for some people 

## How has this been tested ?
<!--- Include details of your testing environment here -->
On Debian Stretch, redirecting and setting back work like a charm

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] My change looks good ;
- [X] I have updated the _README.md_ file accordingly ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
