### PR TITLE
Add Support for WSL Distros

### DIFF
--- a/archey/archey.py
+++ b/archey/archey.py
@@ -951,8 +951,8 @@ class Disk:
                 '-t', 'ext4', '-t', 'ext3', '-t', 'ext2',
                 '-t', 'reiserfs', '-t', 'jfs', '-t', 'zfs',
                 '-t', 'ntfs', '-t', 'fat32', '-t', 'btrfs',
-                '-t', 'fuseblk', '-t', 'xfs',
-                '-t', 'simfs', '-t', 'tmpfs'
+                '-t', 'fuseblk', '-t', 'xfs', '-t', 'simfs',
+                '-t', 'tmpfs', '-t', 'lxfs'
                 ], universal_newlines=True
             ).splitlines()[-1]
         ).split()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added support for the filesystem used by Windows Subsystem for Linux filesystem.
Originally submitted here https://github.com/djmelik/archey/pull/45

nb: the User will still need to either cat /proc/self/mounts > /etc/mtab or create a symlink

## Reason and / or context
Allows archey to be used with WSL distro's


## How has this been tested ?
Locally tested


## Types of changes :
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
- [x] My change looks good ;
- [ ] I have updated the test cases (which pass) accordingly ;
- [ ] I have updated the _README.md_ file accordingly ;
- [x] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
