### PR TITLE
Hide `Max.` temperature when there is only one value

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,9 +18,10 @@
 
 ## Your environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
-* Version used (4.x.y) : 
+* Version used (4.Y.Z) : 
 * Method of installation (package, PIP, from sources, ...) : 
 * Hardware type (laptop, server, Raspberry, hyper-visor, ...) : 
+* Python version (3.Y.Z) : 
 * Operating system and version : 
 * Graphical environment name and version : 
 * Connectivity (off-line, LAN only, Internet access, ...) : 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Now, it's time to use your favorite package manager. Some examples :
 	$ sudo pacman -U ./archey4-v4.Y.Z-R-any.pkg.tar.xz
 	```
 
-* Debian-based distributions ([source](https://labs.pixelswap.fr/HorlogeSkynet/archey4-packaging))
+* Debian-based distributions ([source](https://git.forestier.app/HorlogeSkynet/archey4-packaging))
 
 	```shell
 	$ sudo apt install ./archey4-v4.Y.Z-R-all.deb

--- a/archey/archey.py
+++ b/archey/archey.py
@@ -824,17 +824,22 @@ class Temperature:
                 if temp != 0.0:
                     temps.append(
                         self._convert_to_fahrenheit(temp)
-                        if CONFIG.get('temperature')['use_fahrenheit']
-                        else temp
+                        if CONFIG.get('temperature')['use_fahrenheit'] else temp
                     )
 
         if temps:
-            self.value = '{0}{2}{3} (Max. {1}{2}{3})'.format(
+            self.value = '{0}{1}{2}'.format(
                 str(round(sum(temps) / len(temps), 1)),
-                str(round(max(temps), 1)),
                 CONFIG.get('temperature')['char_before_unit'],
                 'F' if CONFIG.get('temperature')['use_fahrenheit'] else 'C'
             )
+
+            if len(temps) > 1:
+                self.value += ' (Max. {0}{1}{2})'.format(
+                    str(round(max(temps), 1)),
+                    CONFIG.get('temperature')['char_before_unit'],
+                    'F' if CONFIG.get('temperature')['use_fahrenheit'] else 'C'
+                )
 
         else:
             self.value = CONFIG.get('default_strings')['not_detected']

--- a/test/test_archey_temperature.py
+++ b/test/test_archey_temperature.py
@@ -40,8 +40,8 @@ class TestTemperatureEntry(unittest.TestCase):
         'archey.archey.glob',
         return_value=[]  # No temperature from file will be retrieved
     )
-    def test_vcgencmd_only(self, glob_mock, check_output_mock):
-        self.assertRegex(Temperature().value, r'42\.8.?.? \(Max\. 42\.8.?.?\)')
+    def test_vcgencmd_only_no_max(self, glob_mock, check_output_mock):
+        self.assertRegex(Temperature().value, r'42\.8.?.?')
 
     @patch(
         'archey.archey.check_output',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->


## Description
<!--- Describe your changes in detail -->
Simple conditional string concatenation which adds the `Max.` temperature detail if there are more than one value retrieved.

> I also added an entry for Python version to the issue template, for debugging and helping purposes.

Bye :wave:

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
When the device got only one temperature value, there is no need to compute and show the maximum.
This is still contestable and open for debate !

## How has this been tested ?
<!--- Include details of your testing environment here -->
- [X] Test cases
- [X] Debian 10

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [x] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My change looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
