### PR TITLE
Fixes CI by dealing with Pylint `no-else-raise` rule, now fixed

### DIFF
--- a/test/test_archey_lan_ip_manual.py
+++ b/test/test_archey_lan_ip_manual.py
@@ -90,13 +90,11 @@ class FakeCheckOutputMock:
             if issubclass(answer[1].__class__, OSError().__class__):
                 raise answer[1]
 
-            else:
-                # The branch is not used here, but maybe it'll help someone ;)
-                return answer[1]
+            # The branch is not used here, but maybe it'll help someone ;)
+            return answer[1]
 
-        else:
-            # Call the specified method with the arguments passed to the mock.
-            return answer[1](*args, **kwargs)
+        # Call the specified method with the arguments passed to the mock.
+        return answer[1](*args, **kwargs)
 
 # --------------------------------------------------------------------------------
 

--- a/test/test_archey_model.py
+++ b/test/test_archey_model.py
@@ -116,8 +116,8 @@ class TestModelEntry(unittest.TestCase):
         # Either return value or raise any specified exception
         if issubclass(return_value.__class__, OSError().__class__):
             raise return_value
-        else:
-            return return_value
+
+        return return_value
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->


## Description
<!--- Describe your changes in detail -->
CI failed yesterday.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
The [v2.3.0 of Pylint has added `no-else-raise` rule](https://github.com/PyCQA/pylint/pull/2636), causing the CI to fail on test cases yesterday, after a README edition.


## How has this been tested ?
<!--- Include details of your testing environment here -->
Locally + Travis.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My change looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
