### PR TITLE
Feature / Bugfix : Proper BTRFS support

### DIFF
--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -72,9 +72,10 @@ class Disk:
 
         # JSON output support landed very "late" in `btrfs-progs` user-space binaries.
         # We are parsing it the hard way to increase compatibility...
-        size_used_regex = re.compile(r"size (\d+\.\d+)GiB used (\d+\.\d+)GiB")
-        for line in btrfs_output.splitlines():
-            matches = size_used_regex.search(line)
-            if matches:
-                self._usage['used'] += float(matches.group(2))
-                self._usage['total'] += float(matches.group(1))
+        for total, used in re.findall(
+                r"size (\d+\.\d+)GiB used (\d+\.\d+)GiB",
+                btrfs_output,
+                flags=re.MULTILINE
+            ):
+            self._usage['used'] += float(used)
+            self._usage['total'] += float(total)

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -15,8 +15,8 @@ class Disk:
     def __init__(self):
         # This dictionary will store values obtained from sub-processes calls.
         self._usage = {
-            'used': 0,
-            'total': 0
+            'used': 0.0,
+            'total': 0.0
         }
 
         # Fetch the user-defined RAM limits from configuration.

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -1,7 +1,5 @@
 """Disk usage detection class"""
 
-import re
-
 from bisect import bisect
 from subprocess import check_output
 
@@ -12,32 +10,41 @@ from archey.configuration import Configuration
 class Disk:
     """Uses `df` command output to compute the total disk usage across devices"""
     def __init__(self):
+        # This dictionary will store values obtained from sub-processes calls.
+        self._usage = {
+            'used': 0,
+            'total': 0
+        }
+
         # Fetch the user-defined RAM limits from configuration.
         disk_limits = Configuration().get('limits')['disk']
 
-        total = re.sub(
-            ',', '.',
-            check_output(
-                [
-                    'df', '-Tlh', '-B', 'GB', '--total',
-                    '-t', 'ext4', '-t', 'ext3', '-t', 'ext2',
-                    '-t', 'reiserfs', '-t', 'jfs', '-t', 'zfs',
-                    '-t', 'ntfs', '-t', 'fat32', '-t', 'btrfs',
-                    '-t', 'fuseblk', '-t', 'xfs', '-t', 'simfs',
-                    '-t', 'tmpfs', '-t', 'lxfs'
-                ], universal_newlines=True
-            ).splitlines()[-1]
-        ).split()
+        self._run_df_usage()
 
         # Based on the disk percentage usage, select the corresponding threshold color.
         color_selector = bisect(
             [disk_limits['warning'], disk_limits['danger']],
-            float(total[5][:-1])
+            (self._usage['used'] / self._usage['total']) * 100
         )
 
-        self.value = '{0}{1}{2} / {3}'.format(
+        self.value = '{0}{1} GB{2} / {3} GB'.format(
             COLOR_DICT['sensors'][color_selector],
-            re.sub('GB', ' GB', total[3]),
+            self._usage['used'],
             COLOR_DICT['clear'],
-            re.sub('GB', ' GB', total[2])
+            self._usage['total']
         )
+
+    def _run_df_usage(self):
+        df_output = check_output(
+            [
+                'df', '-l', '-B', 'GB', '--total',
+                '-t', 'ext4', '-t', 'ext3', '-t', 'ext2',
+                '-t', 'reiserfs', '-t', 'jfs', '-t', 'zfs',
+                '-t', 'ntfs', '-t', 'fat32', '-t', 'fuseblk',
+                '-t', 'xfs', '-t', 'simfs', '-t', 'lxfs'
+            ],
+            env={'LANG': 'C'}, universal_newlines=True
+        ).splitlines()[-1].split()
+
+        self._usage['used'] += int(df_output[2].rstrip('GB'))
+        self._usage['total'] += int(df_output[1].rstrip('GB'))

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -42,7 +42,7 @@ class Disk:
         try:
             df_output = check_output(
                 [
-                    'df', '-l', '-P', '-B', 'GB', '--total',
+                    'df', '-l', '-P', '-B', 'MB', '--total',
                     '-t', 'ext2', '-t', 'ext3', '-t', 'ext4',
                     '-t', 'fat32',
                     '-t', 'fuseblk',
@@ -60,8 +60,8 @@ class Disk:
             # It looks like there is not any file system matching our types.
             return
 
-        self._usage['used'] += int(df_output[2].rstrip('GB'))
-        self._usage['total'] += int(df_output[1].rstrip('GB'))
+        self._usage['used'] += float(df_output[2].rstrip('MB')) / 1024
+        self._usage['total'] += float(df_output[1].rstrip('MB')) / 1024
 
     def _run_btrfs_fi_show(self):
         try:

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -31,7 +31,7 @@ class Disk:
             (self._usage['used'] / self._usage['total']) * 100
         )
 
-        self.value = '{0}{1} GB{2} / {3} GB'.format(
+        self.value = '{0}{1} GiB{2} / {3} GiB'.format(
             COLOR_DICT['sensors'][color_selector],
             round(self._usage['used'], 1),
             COLOR_DICT['clear'],

--- a/archey/test/test_archey_configuration.py
+++ b/archey/test/test_archey_configuration.py
@@ -125,12 +125,12 @@ class TestConfigurationUtil(unittest.TestCase):
         configuration._config = {  # pylint: disable=protected-access
             'allow_overriding': True,
             'suppress_warnings': False,
-            'colors_palette': {
-                'use_unicode': False
-            },
             'default_strings': {
                 'no_address': 'No Address',
                 'not_detected': 'Not detected'
+            },
+            'colors_palette': {
+                'use_unicode': False
             },
             'ip_settings': {
                 'lan_ip_max_count': 2

--- a/archey/test/test_archey_configuration.py
+++ b/archey/test/test_archey_configuration.py
@@ -20,7 +20,7 @@ class TestConfigurationUtil(unittest.TestCase):
         configuration = Configuration()
         configuration._config = {  # pylint: disable=protected-access
             'ip_settings': {
-                'lan_ip_max_count': 2,
+                'lan_ip_max_count': 2
             },
             'temperature': {
                 'use_fahrenheit': False
@@ -130,7 +130,7 @@ class TestConfigurationUtil(unittest.TestCase):
             },
             'default_strings': {
                 'no_address': 'No Address',
-                'not_detected': 'Not detected',
+                'not_detected': 'Not detected'
             },
             'ip_settings': {
                 'lan_ip_max_count': 2
@@ -151,7 +151,7 @@ class TestConfigurationUtil(unittest.TestCase):
                 'default_strings': {
                     'no_address': '\xde\xad \xbe\xef',
                     'not_detected': 'Not detected',
-                    'virtual_environment': 'Virtual Environment',
+                    'virtual_environment': 'Virtual Environment'
                 },
                 'temperature': {
                     'a_weird_new_dict': [
@@ -176,7 +176,7 @@ class TestConfigurationUtil(unittest.TestCase):
                 'default_strings': {
                     'no_address': '\xde\xad \xbe\xef',
                     'not_detected': 'Not detected',
-                    'virtual_environment': 'Virtual Environment',
+                    'virtual_environment': 'Virtual Environment'
                 },
                 'ip_settings': {
                     'lan_ip_max_count': 2

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -13,10 +13,10 @@ class TestDiskEntry(unittest.TestCase):
     @patch(
         'archey.entries.disk.check_output',
         return_value="""\
-Filesystem       Type 1GB-blocks  Used Available Use% Mounted on
-/dev/mapper/root ext4      512GB  14GB     498GB   2% /
-/dev/mapper/home ext3      512GB  47GB     465GB   9% /home
-total            -        1024GB  61GB     963GB  11% -
+Filesystem       1GB-blocks  Used Available Use% Mounted on
+/dev/mapper/root      512GB  14GB     498GB   2% /
+/dev/mapper/home      512GB  47GB     465GB   9% /home
+total                1024GB  61GB     963GB  11% -
 """)
     @patch(
         'archey.entries.disk.Configuration.get',

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -16,10 +16,11 @@ class TestDiskEntry(unittest.TestCase):
         'archey.entries.disk.check_output',
         side_effect=[
             """\
-Filesystem       1000000000-blocks  Used Available Capacity Mounted on
-/dev/mapper/root             512GB  14GB     498GB       2% /
-/dev/mapper/home             512GB  47GB     465GB       9% /home
-total                       1024GB  61GB     963GB      11% -
+Filesystem       1000000-blocks    Used Available Capacity Mounted on
+/dev/mapper/root        39101MB 14216MB   22870MB      39% /
+/dev/sda1                 967MB    91MB     810MB      11% /boot
+/dev/mapper/home       265741MB 32700MB  219471MB      13% /home
+total                  305809MB 47006MB  243149MB      17% -
 """,
             FileNotFoundError()  # `btrfs` call will fail.
         ]
@@ -34,18 +35,19 @@ total                       1024GB  61GB     963GB      11% -
         }
     )
     def test_df_only(self, _, __):
-        """Test computations around `df` output at disk normal level"""
+        """Test computations around `df` output at disk regular level"""
         disk = Disk().value
-        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '61', '1024']))
+        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '45.9', '298.6']))
 
     @patch(
         'archey.entries.disk.check_output',
         side_effect=[
             """\
-Filesystem       1000000000-blocks  Used Available Capacity Mounted on
-/dev/mapper/root             512GB 314GB     198GB      61% /
-/dev/mapper/home             512GB 347GB     165GB      68% /home
-total                       1024GB 661GB     363GB      65% -
+Filesystem       1000000-blocks     Used Available Capacity Mounted on
+/dev/mapper/root        39101MB  14216MB   22870MB      39% /
+/dev/sda1                 967MB     91MB     810MB      11% /boot
+/dev/mapper/home       265741MB 243291MB   22450MB      92% /home
+total                  305809MB 257598MB   46130MB      84% -
 """,
             FileNotFoundError()  # `btrfs` call will fail.
         ]
@@ -54,24 +56,25 @@ total                       1024GB 661GB     363GB      65% -
         'archey.entries.disk.Configuration.get',
         return_value={
             'disk': {
-                'warning': 50,
-                'danger': 75
+                'warning': 80,
+                'danger': 90
             }
         }
     )
     def test_df_only_warning(self, _, __):
         """Test computations around `df` output at disk warning level"""
         disk = Disk().value
-        self.assertTrue(all(i in disk for i in ['\x1b[0;33m', '661', '1024']))
+        self.assertTrue(all(i in disk for i in ['\x1b[0;33m', '251.6', '298.6']))
 
     @patch(
         'archey.entries.disk.check_output',
         side_effect=[
             """\
-Filesystem       1GB-blocks  Used Available Use% Mounted on
-/dev/mapper/root      512GB  14GB     498GB   2% /
-/dev/mapper/home      512GB  47GB     465GB   9% /home
-total                1024GB  61GB     963GB  11% -
+Filesystem       1000000-blocks    Used Available Capacity Mounted on
+/dev/mapper/root        39101MB 14216MB   22870MB      39% /
+/dev/sda1                 967MB    91MB     810MB      11% /boot
+/dev/mapper/home       265741MB 32700MB  219471MB      13% /home
+total                  305809MB 47006MB  243149MB      17% -
 """,
             """\
 Label: none  uuid: ac1d4ab8-6ea1-11ea-bc55-0242ac130003
@@ -105,7 +108,7 @@ Label: none  uuid: c168c2e4-6ea1-11ea-bc55-0242ac130003
     def test_df_and_btrfs(self, _, __):
         """Test computations around `df` and `btrfs` outputs"""
         disk = Disk().value
-        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '82.5', '1101.8']))
+        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '67.4', '376.5']))
 
     @patch(
         'archey.entries.disk.check_output',

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -87,6 +87,7 @@ Label: none  uuid: bb675216-6ea1-11ea-bc55-0242ac130003
 Label: none  uuid: c168c2e4-6ea1-11ea-bc55-0242ac130003
 	Total devices 1 FS bytes used 0.00GiB
 	devid    1 size 9.36GiB used 1.24GiB path /dev/vda7
+
 """
         ]
     )

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -126,7 +126,7 @@ Label: none  uuid: c168c2e4-6ea1-11ea-bc55-0242ac130003
     def test_failing_df_and_empty_btrfs(self, _, __):
         """Test computations around `df` and `btrfs` outputs"""
         disk = Disk().value
-        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '0']))
+        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '0.0']))
 
 if __name__ == '__main__':
     unittest.main()

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -1,5 +1,7 @@
 """Test module for Archey's disks usage detection module"""
 
+from subprocess import CalledProcessError
+
 import unittest
 from unittest.mock import patch
 
@@ -104,6 +106,27 @@ Label: none  uuid: c168c2e4-6ea1-11ea-bc55-0242ac130003
         """Test computations around `df` and `btrfs` outputs"""
         disk = Disk().value
         self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '82.5', '1101.8']))
+
+    @patch(
+        'archey.entries.disk.check_output',
+        side_effect=[
+            CalledProcessError(1, "df: no file systems processed"),
+            '\n'
+        ]
+    )
+    @patch(
+        'archey.entries.disk.Configuration.get',
+        return_value={
+            'disk': {
+                'warning': 50,
+                'danger': 75
+            }
+        }
+    )
+    def test_failing_df_and_empty_btrfs(self, _, __):
+        """Test computations around `df` and `btrfs` outputs"""
+        disk = Disk().value
+        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '0']))
 
 if __name__ == '__main__':
     unittest.main()

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -8,16 +8,20 @@ from archey.entries.disk import Disk
 
 class TestDiskEntry(unittest.TestCase):
     """
-    Here, we mock the `check_output` call to `df` using all three cases of available space.
+    Here, we mock `check_output` calls to disk utility tools.
     """
     @patch(
         'archey.entries.disk.check_output',
-        return_value="""\
-Filesystem       1GB-blocks  Used Available Use% Mounted on
-/dev/mapper/root      512GB  14GB     498GB   2% /
-/dev/mapper/home      512GB  47GB     465GB   9% /home
-total                1024GB  61GB     963GB  11% -
-""")
+        side_effect=[
+            """\
+Filesystem       1000000000-blocks  Used Available Capacity Mounted on
+/dev/mapper/root             512GB  14GB     498GB       2% /
+/dev/mapper/home             512GB  47GB     465GB       9% /home
+total                       1024GB  61GB     963GB      11% -
+""",
+            FileNotFoundError()  # `btrfs` call will fail.
+        ]
+    )
     @patch(
         'archey.entries.disk.Configuration.get',
         return_value={
@@ -27,19 +31,23 @@ total                1024GB  61GB     963GB  11% -
             }
         }
     )
-    def test(self, _, __):
+    def test_df_only(self, _, __):
         """Test computations around `df` output at disk normal level"""
         disk = Disk().value
         self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '61', '1024']))
 
     @patch(
         'archey.entries.disk.check_output',
-        return_value="""\
-Filesystem       Type 1GB-blocks  Used Available Use% Mounted on
-/dev/mapper/root ext4      512GB 314GB     198GB  61% /
-/dev/mapper/home ext3      512GB 347GB     165GB  68% /home
-total            -        1024GB 661GB     363GB  65% -
-""")
+        side_effect=[
+            """\
+Filesystem       1000000000-blocks  Used Available Capacity Mounted on
+/dev/mapper/root             512GB 314GB     198GB      61% /
+/dev/mapper/home             512GB 347GB     165GB      68% /home
+total                       1024GB 661GB     363GB      65% -
+""",
+            FileNotFoundError()  # `btrfs` call will fail.
+        ]
+    )
     @patch(
         'archey.entries.disk.Configuration.get',
         return_value={
@@ -49,33 +57,52 @@ total            -        1024GB 661GB     363GB  65% -
             }
         }
     )
-    def test_warning(self, _, __):
+    def test_df_only_warning(self, _, __):
         """Test computations around `df` output at disk warning level"""
         disk = Disk().value
         self.assertTrue(all(i in disk for i in ['\x1b[0;33m', '661', '1024']))
 
     @patch(
         'archey.entries.disk.check_output',
-        return_value="""\
-Filesystem       Type 1GB-blocks  Used Available Use% Mounted on
-/dev/mapper/root ext4      512GB 414GB      98GB  81% /
-/dev/mapper/home ext3      512GB 447GB      65GB  87% /home
-total            -        1024GB 861GB     163GB  84% -
-""")
+        side_effect=[
+            """\
+Filesystem       1GB-blocks  Used Available Use% Mounted on
+/dev/mapper/root      512GB  14GB     498GB   2% /
+/dev/mapper/home      512GB  47GB     465GB   9% /home
+total                1024GB  61GB     963GB  11% -
+""",
+            """\
+Label: none  uuid: ac1d4ab8-6ea1-11ea-bc55-0242ac130003
+	Total devices 1 FS bytes used 6.23GiB
+	devid    1 size 55.97GiB used 17.12GiB path /dev/vda1
+
+Label: none  uuid: b749f0c6-6ea1-11ea-bc55-0242ac130003
+	Total devices 1 FS bytes used 0.00GiB
+	devid    1 size 3.15GiB used 0.99GiB path /dev/vda8
+
+Label: none  uuid: bb675216-6ea1-11ea-bc55-0242ac130003
+	Total devices 1 FS bytes used 0.52GiB
+	devid    1 size 9.37GiB used 2.12GiB path /dev/vda6
+
+Label: none  uuid: c168c2e4-6ea1-11ea-bc55-0242ac130003
+	Total devices 1 FS bytes used 0.00GiB
+	devid    1 size 9.36GiB used 1.24GiB path /dev/vda7
+"""
+        ]
+    )
     @patch(
         'archey.entries.disk.Configuration.get',
         return_value={
             'disk': {
-                'warning': 75,
-                'danger': 90
+                'warning': 50,
+                'danger': 75
             }
         }
     )
-    def test_danger(self, _, __):
-        """Test computations around `df` output at disk danger level and tweaked limits"""
+    def test_df_and_btrfs(self, _, __):
+        """Test computations around `df` and `btrfs` outputs"""
         disk = Disk().value
-        self.assertTrue(all(i in disk for i in ['\x1b[0;33m', '861', '1024']))
-
+        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '82.5', '1101.8']))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
See #42 for the rationale.
EDIT : I've given up the `/` solution as it would omit all the other **local** mount points as well, and against systems with a `/home` larger than `/` (for instance), it wouldn't be relevant at all.

## How has this been tested ?
<!--- Include details of your testing environment here -->
:warning: Not tested on a real BTRFS system. :warning:

@qx071, are you ready to test / improve / guide me on this ?

---

**EDIT 2019-08-15** : I've figured out that the `btrfs [...]` call being made does not work at all.
So @qx071, I'll definitely need you to properly list BTRFS (sub-)volumes to fetch their meta-data. Waiting for your input on this !

**EDIT 2019-12-24** : To myself (@HorlogeSkynet), don't forget to rename `self.usage` to `self._usage`.

**EDIT 2020-03-25** : Wrong `btrfs` call has been replaced, it _should_ work as expected now.

---

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My change looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
