### PR TITLE
Replaces `wget` fall-back call by a proper `urllib.request` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,12 @@ The answer is [here](https://blog.samuel.domains/archey4).
 
 | Environments |  Packages  |                Reasons                | Notes |
 | :----------- | :--------: | :-----------------------------------: | :---: |
-| All          | `dnsutils` or `bind-tools` | **WAN_IP** would be detected faster | Would provide `dig` |
+| All          | `dnsutils` or `bind-tools` | **WAN\_IP** would be detected faster | Would provide `dig` |
 | Graphical    |  `pciutils` or `pciutils-ng` | **GPU** wouldn't be detected without it | Would provide `lspci` |
 | Graphical    |  `wmctrl` | **WindowManager** would be more accurate | φ |
 | Virtual      | `virt-what` and `dmidecode` | **Model** would contain details about the hypervisor | `archey` would have to be run as **root** |
 
 ### :warning: Various notes to read before going down :warning:
-
-**Without `dnsutils` or `bind-tools` installed, you'll need `wget` in order to retrieve your public IP address.**
 
 **Note to Debian Jessie users : As `python3-distro` module is not available in your repositories, you should opt for an [installation from PIP](#install-with-pip).**
 
@@ -233,3 +231,5 @@ Any improvement would be appreciated.
 * If you experience any trouble during the installation or usage, please do **[open an issue](https://github.com/HorlogeSkynet/archey4/issues/new)**.
 
 * If you had to adapt the script to make it work on your system, please **[open a pull request](https://github.com/HorlogeSkynet/archey4/pulls)** so as to share your modifications with the rest of the world and participate in this project !
+
+* When looking up your public IP address (**WAN\_IP**), Archey will try at first to run a DNS query for `myip.opendns.com`, against OpenDNS's resolver(s). On error, it would fall back on regular HTTPS request(s) to <https://ident.me> ([server sources](https://github.com/pcarrier/identme)).

--- a/archey/entries/wan_ip.py
+++ b/archey/entries/wan_ip.py
@@ -1,8 +1,8 @@
 """Public IP address detection class"""
 
-import sys
-
 from subprocess import check_output, DEVNULL, TimeoutExpired, CalledProcessError
+from urllib.error import URLError
+from urllib.request import urlopen
 
 from archey.configuration import Configuration
 
@@ -16,7 +16,7 @@ class WanIp:
         # IPv6 address retrieval (unless the user doesn't want it).
         if configuration.get('ip_settings')['wan_ip_v6_support']:
             try:
-                ipv6_value = check_output(
+                ipv6_addr = check_output(
                     [
                         'dig', '+short', '-6', 'AAAA', 'myip.opendns.com',
                         '@resolver1.ipv6-sandbox.opendns.com'
@@ -27,30 +27,24 @@ class WanIp:
 
             except (FileNotFoundError, TimeoutExpired, CalledProcessError):
                 try:
-                    ipv6_value = check_output(
-                        [
-                            'wget', '-q6O-', 'https://v6.ident.me/'
-                        ],
-                        timeout=configuration.get('timeout')['ipv6_detection'],
-                        universal_newlines=True
+                    ipv6_addr = urlopen(
+                        'https://v6.ident.me/',
+                        timeout=configuration.get('timeout')['ipv6_detection']
                     )
+                    if ipv6_addr and ipv6_addr.getcode() == 200:
+                        ipv6_addr = ipv6_addr.read().decode().strip()
 
-                except (CalledProcessError, TimeoutExpired):
+                except URLError:
                     # It looks like this user doesn't have any IPv6 address...
                     # ... or is not connected to Internet.
-                    ipv6_value = None
-
-                except FileNotFoundError:
-                    ipv6_value = None
-                    print('Warning: `wget` has not been found on your system.',
-                          file=sys.stderr)
+                    ipv6_addr = None
 
         else:
-            ipv6_value = None
+            ipv6_addr = None
 
         # IPv4 addresses retrieval (anyway).
         try:
-            ipv4_value = check_output(
+            ipv4_addr = check_output(
                 [
                     'dig', '+short', '-4', 'A', 'myip.opendns.com',
                     '@resolver1.opendns.com'
@@ -61,25 +55,17 @@ class WanIp:
 
         except (FileNotFoundError, TimeoutExpired, CalledProcessError):
             try:
-                ipv4_value = check_output(
-                    [
-                        'wget', '-q4O-', 'https://v4.ident.me/'
-                    ],
-                    timeout=configuration.get('timeout')['ipv4_detection'],
-                    universal_newlines=True
+                ipv4_addr = urlopen(
+                    'https://v4.ident.me/',
+                    timeout=configuration.get('timeout')['ipv4_detection']
                 )
+                if ipv4_addr and ipv4_addr.getcode() == 200:
+                    ipv4_addr = ipv4_addr.read().decode().strip()
 
-            except (CalledProcessError, TimeoutExpired):
-                # This user looks not connected to Internet...
-                ipv4_value = None
-
-            except FileNotFoundError:
-                ipv4_value = None
-                # If statement so as to not print the same message twice.
-                if not configuration.get('ip_settings')['wan_ip_v6_support']:
-                    print('Warning: `wget` has not been found on your system.',
-                          file=sys.stderr)
+            except URLError:
+                # The user does not look connected to Internet...
+                ipv4_addr = None
 
         self.value = ', '.join(
-            filter(None, (ipv4_value, ipv6_value))
+            filter(None, (ipv4_addr, ipv6_addr))
         ) or configuration.get('default_strings')['no_address']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Hey all :wave:
Explanations below :

## Description
<!--- Describe your changes in detail -->
This patch replaces old `wget` sub-calls by `urllib.request` usages (that should be consistent across Python 3.X versions).
README has also been updated and now accounts for **WAN\_IP** external connections attempts.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
Keeping `wget` sub-call as an optional dependency is actually weird and useless, as Python 3.X standard library allows us to perform HTTP requests easily.

## How has this been tested ?
<!--- Include details of your testing environment here -->
Personal setup and test cases.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My change looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
