### PR TITLE
Replaces Python site's `exit` by `sys.exit`

### DIFF
--- a/archey/processes.py
+++ b/archey/processes.py
@@ -20,7 +20,7 @@ class Processes(metaclass=Singleton):
         except FileNotFoundError:
             print('Please, install first `procps` on your distribution.',
                   file=sys.stderr)
-            exit()
+            sys.exit(1)
 
     def get(self):
         """Simple getter to retrieve the processes list"""


### PR DESCRIPTION
See PyCQA/pylint#3062.

## Description
<!--- Describe your changes in detail -->
According to [the documentation](https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module), constants from the Python's `site` module shouldn't be used in programs.
I took the opportunity to set a non-OK exit code (`1`) when the `ps` program is not available.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [ ] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My change looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
