### PR TITLE
Allow configurable thresholds for disk and ram warning/danger colors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,15 +205,16 @@ Below, some further explanations of each option available :
 	"timeout": {
 		// Some values you can adjust if the default ones look undersized for your system (seconds).
 	}
-	"ram_limits": {
-		// Some threshold values you can adjust affecting ram warning/danger color (percent).
-		"low": 33.3,
-		"medium": 66.7
-	}
-	"disk_limits": {
-		// Some threshold values you can adjust affecting disk warning/danger color (percent).
-		"low": 50,
-		"medium": 75
+	"limits": {
+		// Some threshold values you can adjust affecting disk/ram warning/danger color (percent).
+		'ram': {
+			"warning": 33.3,
+			"danger": 66.7
+		},
+		'disk': {
+			"warning": 50,
+			"danger": 75
+		}
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ Below, some further explanations of each option available :
 	"timeout": {
 		// Some values you can adjust if the default ones look undersized for your system (seconds).
 	}
+	"ram_limits": {
+		// Some threshold values you can adjust affecting ram warning/danger color (percent).
+		"low": 33.3,
+		"medium": 66.7
+	}
+	"disk_limits": {
+		// Some threshold values you can adjust affecting disk warning/danger color (percent).
+		"low": 50,
+		"medium": 75
+	}
 }
 ```
 

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -36,13 +36,15 @@ class Configuration(metaclass=Singleton):
                 'ipv4_detection': 1,
                 'ipv6_detection': 1
             },
-            'ram_limits': {
-                'low': 33.3,
-                'medium': 66.7
-            },
-            'disk_limits': {
-                'low': 50,
-                'medium': 75
+            'limits': {
+                'ram': {
+                    'warning': 33.3,
+                    'danger': 66.7
+                },
+                'disk': {
+                    'warning': 50,
+                    'danger': 75
+                }
             }
         }
 

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -35,6 +35,14 @@ class Configuration(metaclass=Singleton):
             'timeout': {
                 'ipv4_detection': 1,
                 'ipv6_detection': 1
+            },
+            'ram_limits': {
+                'low': 33.3,
+                'medium': 66.7
+            },
+            'disk_limits': {
+                'low': 50,
+                'medium': 75
             }
         }
 

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -30,11 +30,11 @@ class Disk:
             ).splitlines()[-1]
         ).split()
 
-        low_limit = configuration.get('disk_limits')['low']
-        medium_limit = configuration.get('disk_limits')['medium']
+        warning_limit = configuration.get('limits')['disk']['warning']
+        danger_limit = configuration.get('limits')['disk']['danger']
 
         self.value = '{0}{1}{2} / {3}'.format(
-            COLOR_DICT['sensors'][bisect([low_limit, medium_limit], float(total[5][:-1]))],
+            COLOR_DICT['sensors'][bisect([warning_limit, danger_limit], float(total[5][:-1]))],
             re.sub('GB', ' GB', total[3]),
             COLOR_DICT['clear'],
             re.sub('GB', ' GB', total[2])

--- a/archey/entries/ram.py
+++ b/archey/entries/ram.py
@@ -46,11 +46,11 @@ class RAM:
             if used < 0:
                 used += ram['Cached'] + ram['Buffers']
 
-        low_limit = configuration.get('ram_limits')['low']
-        medium_limit = configuration.get('ram_limits')['medium']
+        warning_limit = configuration.get('limits')['ram']['warning']
+        danger_limit = configuration.get('limits')['ram']['danger']
 
         self.value = '{0}{1} MB{2} / {3} MB'.format(
-            COLOR_DICT['sensors'][bisect([low_limit, medium_limit], (used / total) * 100)],
+            COLOR_DICT['sensors'][bisect([warning_limit, danger_limit], (used / total) * 100)],
             int(used),
             COLOR_DICT['clear'],
             int(total)

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -20,17 +20,17 @@ total            -        1024GB  61GB     963GB  11% -
 """)
     @patch(
         'archey.entries.disk.Configuration.get',
-        side_effect=[
-            {'disk': {'warning': 50}},
-            {'disk': {'danger': 75}},
-        ]
+        return_value={
+            'disk': {
+                'warning': 50,
+                'danger': 75
+            }
+        }
     )
     def test(self, _, __):
         """Test computations around `df` output at disk normal level"""
         disk = Disk().value
-        self.assertIn('\x1b[0;32m', disk)
-        self.assertIn('61', disk)
-        self.assertIn('1024', disk)
+        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '61', '1024']))
 
     @patch(
         'archey.entries.disk.check_output',
@@ -42,17 +42,17 @@ total            -        1024GB 661GB     363GB  65% -
 """)
     @patch(
         'archey.entries.disk.Configuration.get',
-        side_effect=[
-            {'disk': {'warning': 50}},
-            {'disk': {'danger': 75}},
-        ]
+        return_value={
+            'disk': {
+                'warning': 50,
+                'danger': 75
+            }
+        }
     )
     def test_warning(self, _, __):
         """Test computations around `df` output at disk warning level"""
         disk = Disk().value
-        self.assertIn('\x1b[0;33m', disk)
-        self.assertIn('661', disk)
-        self.assertIn('1024', disk)
+        self.assertTrue(all(i in disk for i in ['\x1b[0;33m', '661', '1024']))
 
     @patch(
         'archey.entries.disk.check_output',
@@ -64,17 +64,17 @@ total            -        1024GB 861GB     163GB  84% -
 """)
     @patch(
         'archey.entries.disk.Configuration.get',
-        side_effect=[
-            {'disk': {'warning': 50}},
-            {'disk': {'danger': 75}},
-        ]
+        return_value={
+            'disk': {
+                'warning': 75,
+                'danger': 90
+            }
+        }
     )
     def test_danger(self, _, __):
-        """Test computations around `df` output at disk danger level"""
+        """Test computations around `df` output at disk danger level and tweaked limits"""
         disk = Disk().value
-        self.assertIn('\x1b[0;31m', disk)
-        self.assertIn('861', disk)
-        self.assertIn('1024', disk)
+        self.assertTrue(all(i in disk for i in ['\x1b[0;33m', '861', '1024']))
 
 
 if __name__ == '__main__':

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -21,8 +21,8 @@ total            -        1024GB  61GB     963GB  11% -
     @patch(
         'archey.entries.disk.Configuration.get',
         side_effect=[
-            {'low': 50},
-            {'medium': 75}
+            {'disk': {'warning': 50}},
+            {'disk': {'danger': 75}},
         ]
     )
     def test(self, _, __):
@@ -43,8 +43,8 @@ total            -        1024GB 661GB     363GB  65% -
     @patch(
         'archey.entries.disk.Configuration.get',
         side_effect=[
-            {'low': 50},
-            {'medium': 75}
+            {'disk': {'warning': 50}},
+            {'disk': {'danger': 75}},
         ]
     )
     def test_warning(self, _, __):
@@ -65,8 +65,8 @@ total            -        1024GB 861GB     163GB  84% -
     @patch(
         'archey.entries.disk.Configuration.get',
         side_effect=[
-            {'low': 50},
-            {'medium': 75}
+            {'disk': {'warning': 50}},
+            {'disk': {'danger': 75}},
         ]
     )
     def test_danger(self, _, __):

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -8,7 +8,7 @@ from archey.entries.disk import Disk
 
 class TestDiskEntry(unittest.TestCase):
     """
-    Here, we mock the `check_output` call to `df`.
+    Here, we mock the `check_output` call to `df` using all three cases of available space.
     """
     @patch(
         'archey.entries.disk.check_output',
@@ -18,10 +18,63 @@ Filesystem       Type 1GB-blocks  Used Available Use% Mounted on
 /dev/mapper/home ext3      512GB  47GB     465GB   9% /home
 total            -        1024GB  61GB     963GB  11% -
 """)
-    def test(self, _):
-        """Test computations around `df` output"""
-        self.assertIn('61', Disk().value)
-        self.assertIn('1024', Disk().value)
+    @patch(
+        'archey.entries.disk.Configuration.get',
+        side_effect=[
+            {'low': 50},
+            {'medium': 75}
+        ]
+    )
+    def test(self, _, __):
+        """Test computations around `df` output at disk normal level"""
+        disk = Disk().value
+        self.assertIn('\x1b[0;32m', disk)
+        self.assertIn('61', disk)
+        self.assertIn('1024', disk)
+
+    @patch(
+        'archey.entries.disk.check_output',
+        return_value="""\
+Filesystem       Type 1GB-blocks  Used Available Use% Mounted on
+/dev/mapper/root ext4      512GB 314GB     198GB  61% /
+/dev/mapper/home ext3      512GB 347GB     165GB  68% /home
+total            -        1024GB 661GB     363GB  65% -
+""")
+    @patch(
+        'archey.entries.disk.Configuration.get',
+        side_effect=[
+            {'low': 50},
+            {'medium': 75}
+        ]
+    )
+    def test_warning(self, _, __):
+        """Test computations around `df` output at disk warning level"""
+        disk = Disk().value
+        self.assertIn('\x1b[0;33m', disk)
+        self.assertIn('661', disk)
+        self.assertIn('1024', disk)
+
+    @patch(
+        'archey.entries.disk.check_output',
+        return_value="""\
+Filesystem       Type 1GB-blocks  Used Available Use% Mounted on
+/dev/mapper/root ext4      512GB 414GB      98GB  81% /
+/dev/mapper/home ext3      512GB 447GB      65GB  87% /home
+total            -        1024GB 861GB     163GB  84% -
+""")
+    @patch(
+        'archey.entries.disk.Configuration.get',
+        side_effect=[
+            {'low': 50},
+            {'medium': 75}
+        ]
+    )
+    def test_danger(self, _, __):
+        """Test computations around `df` output at disk danger level"""
+        disk = Disk().value
+        self.assertIn('\x1b[0;31m', disk)
+        self.assertIn('861', disk)
+        self.assertIn('1024', disk)
 
 
 if __name__ == '__main__':

--- a/archey/test/test_archey_ram.py
+++ b/archey/test/test_archey_ram.py
@@ -22,8 +22,8 @@ Swap:      7607        5    7602
     @patch(
         'archey.entries.ram.Configuration.get',
         side_effect=[
-            {'low': 33.3},
-            {'medium': 66.7}
+            {'ram': {'warning': 33.3}},
+            {'ram': {'danger': 66.7}},
         ]
     )
     def test_free_dash_m(self, _, __):
@@ -41,8 +41,8 @@ Swap:          4095          39        4056
     @patch(
         'archey.entries.ram.Configuration.get',
         side_effect=[
-            {'low': 33.3},
-            {'medium': 66.7}
+            {'ram': {'warning': 33.3}},
+            {'ram': {'danger': 66.7}},
         ]
     )
     def test_free_dash_m_warning(self, _, __):
@@ -60,8 +60,8 @@ Swap:          4095         160        3935
     @patch(
         'archey.entries.ram.Configuration.get',
         side_effect=[
-            {'low': 33.3},
-            {'medium': 66.7}
+            {'ram': {'warning': 33.3}},
+            {'ram': {'danger': 66.7}},
         ]
     )
     def test_free_dash_m_danger(self, _, __):
@@ -77,8 +77,8 @@ Swap:          4095         160        3935
     @patch(
         'archey.entries.ram.Configuration.get',
         side_effect=[
-            {'low': 33.3},
-            {'medium': 66.7}
+            {'ram': {'warning': 33.3}},
+            {'ram': {'danger': 66.7}},
         ]
     )
     @patch(

--- a/archey/test/test_archey_ram.py
+++ b/archey/test/test_archey_ram.py
@@ -11,7 +11,6 @@ class TestRAMEntry(unittest.TestCase):
     Here, we mock the `check_output` call to `free` using all three levels of available ram.
     In the last test, mock with `/proc/meminfo` file opening during the manual way.
     """
-
     @patch(
         'archey.entries.ram.check_output',
         return_value="""\
@@ -21,15 +20,17 @@ Swap:      7607        5    7602
 """)
     @patch(
         'archey.entries.ram.Configuration.get',
-        side_effect=[
-            {'ram': {'warning': 33.3}},
-            {'ram': {'danger': 66.7}},
-        ]
+        return_value={
+            'ram': {
+                'warning': 25,
+                'danger': 45
+            },
+        }
     )
     def test_free_dash_m(self, _, __):
-        """Test `free -m` output parsing for low ram use case"""
+        """Test `free -m` output parsing for low RAM use case and tweaked limits"""
         ram = RAM().value
-        self.assertTrue(all(i in ram for i in ['\x1b[0;33m', '3341', '7412']))
+        self.assertTrue(all(i in ram for i in ['\x1b[0;31m', '3341', '7412']))
 
     @patch(
         'archey.entries.ram.check_output',
@@ -40,13 +41,15 @@ Swap:          4095          39        4056
 """)
     @patch(
         'archey.entries.ram.Configuration.get',
-        side_effect=[
-            {'ram': {'warning': 33.3}},
-            {'ram': {'danger': 66.7}},
-        ]
+        return_value={
+            'ram': {
+                'warning': 33.3,
+                'danger': 66.7
+            },
+        }
     )
     def test_free_dash_m_warning(self, _, __):
-        """Test `free -m` output parsing for warning ram use case"""
+        """Test `free -m` output parsing for warning RAM use case"""
         ram = RAM().value
         self.assertTrue(all(i in ram for i in ['\x1b[0;32m', '2043', '15658']))
 
@@ -59,16 +62,17 @@ Swap:          4095         160        3935
 """)
     @patch(
         'archey.entries.ram.Configuration.get',
-        side_effect=[
-            {'ram': {'warning': 33.3}},
-            {'ram': {'danger': 66.7}},
-        ]
+        return_value={
+            'ram': {
+                'warning': 33.3,
+                'danger': 66.7
+            },
+        }
     )
     def test_free_dash_m_danger(self, _, __):
-        """Test `free -m` output parsing for danger ram use case"""
+        """Test `free -m` output parsing for danger RAM use case"""
         ram = RAM().value
         self.assertTrue(all(i in ram for i in ['\x1b[0;31m', '12341', '15658']))
-
 
     @patch(
         'archey.entries.ram.check_output',
@@ -76,10 +80,12 @@ Swap:          4095         160        3935
     )
     @patch(
         'archey.entries.ram.Configuration.get',
-        side_effect=[
-            {'ram': {'warning': 33.3}},
-            {'ram': {'danger': 66.7}},
-        ]
+        return_value={
+            'ram': {
+                'warning': 33.3,
+                'danger': 66.7
+            },
+        }
     )
     @patch(
         'archey.entries.ram.open',

--- a/archey/test/test_archey_ram.py
+++ b/archey/test/test_archey_ram.py
@@ -29,7 +29,7 @@ Swap:      7607        5    7602
     def test_free_dash_m(self, _, __):
         """Test `free -m` output parsing for low ram use case"""
         ram = RAM().value
-        self.assertTrue(all(i in ram for i in ['\x1b[0;33m' '3341', '7412']))
+        self.assertTrue(all(i in ram for i in ['\x1b[0;33m', '3341', '7412']))
 
     @patch(
         'archey.entries.ram.check_output',
@@ -48,7 +48,7 @@ Swap:          4095          39        4056
     def test_free_dash_m_warning(self, _, __):
         """Test `free -m` output parsing for warning ram use case"""
         ram = RAM().value
-        self.assertTrue(all(i in ram for i in ['\x1b[0;32m' '2043', '15658']))
+        self.assertTrue(all(i in ram for i in ['\x1b[0;32m', '2043', '15658']))
 
     @patch(
         'archey.entries.ram.check_output',
@@ -67,7 +67,7 @@ Swap:          4095         160        3935
     def test_free_dash_m_danger(self, _, __):
         """Test `free -m` output parsing for danger ram use case"""
         ram = RAM().value
-        self.assertTrue(all(i in ram for i in ['\x1b[0;31m' '12341', '15658']))
+        self.assertTrue(all(i in ram for i in ['\x1b[0;31m', '12341', '15658']))
 
 
     @patch(
@@ -108,7 +108,7 @@ Dirty:               200 kB
     def test_proc_meminfo(self, _, __):
         """Test `/proc/meminfo` parsing (when `free` is not available)"""
         ram = RAM().value
-        self.assertTrue(all(i in ram for i in ['\x1b[0;33m' '3556', '7412']))
+        self.assertTrue(all(i in ram for i in ['\x1b[0;33m', '3556', '7412']))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
A minor change that allows the warning and danger thresholds of the disk and ram sections to be configurable.

## Reason and / or context
Different users have different opinions on when they would like to be warned about disk/ram usage.

## How has this been tested ?
On my arch linux system.

## Types of changes :
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [x] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [x] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [x] My change looks good ;
- [x] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
