### PR TITLE
[DISK] BTRFS implementation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The answer is [here](https://blog.samuel.domains/archey4).
 | Graphical    | `pciutils` | **GPU** wouldn't be detected without it | Would provide `lspci` |
 | Graphical    | `wmctrl` | **WindowManager** would be more accurate | φ |
 | Virtual      | `virt-what` and `dmidecode` | **Model** would contain details about the hypervisor | `archey` would have to be run as **root** |
+| Btrfs systems | `btrfs-progs` | **Disk** support for btrfs | φ |
 
 ### :warning: Various notes to read before going down :warning:
 

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ The answer is [here](https://blog.samuel.domains/archey4).
 
 ### Highly recommended packages
 
-| Environments |  Packages  |                Reasons                | Notes |
-| :----------- | :--------: | :-----------------------------------: | :---: |
-| All          | `dnsutils` or `bind-tools` | **WAN\_IP** would be detected faster | Would provide `dig` |
-| All          | `lm-sensors` or `lm_sensors` | **Temperature** would be more accurate | φ |
-| Graphical    | `pciutils` | **GPU** wouldn't be detected without it | Would provide `lspci` |
-| Graphical    | `wmctrl` | **WindowManager** would be more accurate | φ |
-| Virtual      | `virt-what` and `dmidecode` | **Model** would contain details about the hypervisor | `archey` would have to be run as **root** |
-| Btrfs systems | `btrfs-progs` or `btrfs-tools` | **Disk** support for btrfs | φ |
+|     Environments      |              Packages               |                       Reasons                        |            Notes             |
+| :-----------------    | :---------------------------------: | :--------------------------------------------------: | :--------------------------: |
+| All                   | `dnsutils` (maybe `bind-tools`)     | **WAN\_IP** would be detected faster                 | Would provide `dig`          |
+| All                   | `lm-sensors` (maybe `lm_sensors`)   | **Temperature** would be more accurate               | N/A                          |
+| Graphical (desktop)   | `pciutils`                          | **GPU** wouldn't be detected without it              | Would provide `lspci`        |
+| Graphical (desktop)   | `wmctrl`                            | **WindowManager** would be more accurate             | N/A                          |
+| Virtual w/o `systemd` | `virt-what` and `dmidecode`         | **Model** would contain details about the hypervisor | **root** privileges required |
+| BTRFS file-systems    | `btrfs-progs` (maybe `btrfs-tools`) | **Disk** would support BTRFS usage computations      | N/A                          |
 
 ### :warning: Various notes to read before going down :warning:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The answer is [here](https://blog.samuel.domains/archey4).
 | Graphical    | `pciutils` | **GPU** wouldn't be detected without it | Would provide `lspci` |
 | Graphical    | `wmctrl` | **WindowManager** would be more accurate | φ |
 | Virtual      | `virt-what` and `dmidecode` | **Model** would contain details about the hypervisor | `archey` would have to be run as **root** |
-| Btrfs systems | `btrfs-progs` | **Disk** support for btrfs | φ |
+| Btrfs systems | `btrfs-progs` or `btrfs-tools` | **Disk** support for btrfs | φ |
 
 ### :warning: Various notes to read before going down :warning:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The answer is [here](https://blog.samuel.domains/archey4).
 | Graphical (desktop)   | `pciutils`                          | **GPU** wouldn't be detected without it              | Would provide `lspci`        |
 | Graphical (desktop)   | `wmctrl`                            | **WindowManager** would be more accurate             | N/A                          |
 | Virtual w/o `systemd` | `virt-what` and `dmidecode`         | **Model** would contain details about the hypervisor | **root** privileges required |
-| BTRFS file-systems    | `btrfs-progs` (maybe `btrfs-tools`) | **Disk** would support BTRFS usage computations      | N/A                          |
+| BTRFS file-systems    | `btrfs-progs` (maybe `btrfs-tools`) | **Disk** would support BTRFS in usage computations   | N/A                          |
 
 ### :warning: Various notes to read before going down :warning:
 

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -2,8 +2,6 @@
 
 from bisect import bisect
 
-import re
-
 from subprocess import check_output, CalledProcessError, DEVNULL
 
 from archey.constants import COLOR_DICT
@@ -80,7 +78,7 @@ class Disk:
         except CalledProcessError:
             # No btrfs filesystems present.
             return
-        
+
         # Eliminate duplicate mounts (e.g. different subvolumes)
         btrfs_unique_mounts = []
         for mountpoint in btrfs_mounts:
@@ -115,10 +113,10 @@ class Disk:
                 physical_device_size.append(float(line.split()[2].rstrip("GiB")))
             if line.startswith("Data ratio"):
                 data_ratios.append(float(line.split()[2]))
-        
-        # Divide physical space by the corresponding data ratio to get space 
+
+        # Divide physical space by the corresponding data ratio to get space
         # used for that group.
-        logical_device_used = [x / y for x,y in zip(physical_device_used, data_ratios)]
-        logical_device_size = [x / y for x,y in zip(physical_device_size, data_ratios)]
+        logical_device_used = [x / y for x, y in zip(physical_device_used, data_ratios)]
+        logical_device_size = [x / y for x, y in zip(physical_device_size, data_ratios)]
         self._usage['total'] += sum(logical_device_size)
         self._usage['used'] += sum(logical_device_used)

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -4,7 +4,7 @@ from bisect import bisect
 
 import re
 
-from subprocess import check_output, CalledProcessError
+from subprocess import check_output, CalledProcessError, DEVNULL
 
 from archey.constants import COLOR_DICT
 from archey.configuration import Configuration
@@ -19,7 +19,7 @@ class Disk:
             'total': 0.0
         }
 
-        # Fetch the user-defined RAM limits from configuration.
+        # Fetch the user-defined disk limits from configuration.
         disk_limits = Configuration().get('limits')['disk']
 
         self._run_df_usage()
@@ -54,7 +54,7 @@ class Disk:
                     '-t', 'xfs',
                     '-t', 'zfs'
                 ],
-                env={'LANG': 'C'}, universal_newlines=True
+                env={'LANG': 'C'}, universal_newlines=True, stderr=DEVNULL
             ).splitlines()[-1].split()
         except CalledProcessError:
             # It looks like there is not any file system matching our types.
@@ -64,22 +64,61 @@ class Disk:
         self._usage['total'] += float(df_output[1].rstrip('MB')) / 1024
 
     def _run_btrfs_fi_show(self):
+        """
+        Since btrfs filesystems can span multiple disks, we fetch all mounted
+        btrfs filesystems, retrieve the btrfs partitions associated with each,
+        and remove all mountpoints with common partitions, then query filesystem
+        usage for each remaining mountpoint.
+        """
         try:
-            # Here we ask for (local) BTRFS file-systems details.
-            btrfs_output = check_output(
-                ['btrfs', 'filesystem', 'show', '--gbytes'],
-                env={'LANG': 'C'}, universal_newlines=True
-            )
-        except (FileNotFoundError, CalledProcessError):
-            # `btrfs` CLI tool doesn't look available.
+            # Retrieve all mountpoints containing btrfs filesystems
+            df_btrfs_output = check_output(
+                ['df', '-l', '-P', '-t', 'btrfs'],
+                env={'LANG': 'C'}, universal_newlines=True, stderr=DEVNULL
+            ).splitlines()[1:]
+            btrfs_mounts = [line.split()[5] for line in df_btrfs_output]
+        except CalledProcessError:
+            # No btrfs filesystems present.
             return
+        
+        # Eliminate duplicate mounts (e.g. different subvolumes)
+        btrfs_unique_mounts = []
+        for mountpoint in btrfs_mounts:
+            try:
+                btrfs_mount_output = check_output(
+                    ['btrfs', 'device', 'usage', mountpoint],
+                    env={'LANG': 'C'}, universal_newlines=True, stderr=DEVNULL
+                ).splitlines()
+            except (FileNotFoundError, CalledProcessError):
+                # `btrfs-progs` not available.
+                return
+            if btrfs_mount_output not in btrfs_unique_mounts:
+                btrfs_unique_mounts.append(mountpoint)
 
+        # Query all unique mountpoints for usage.
+        btrfs_command = ['btrfs', 'filesystem', 'usage', '-g']
+        btrfs_command.extend(btrfs_unique_mounts)
+        btrfs_mount_output = [
+            line.strip() for line in check_output(
+                btrfs_command, env={'LANG': 'C'}, universal_newlines=True, stderr=DEVNULL
+            ).splitlines()
+        ]
         # JSON output support landed very "late" in `btrfs-progs` user-space binaries.
         # We are parsing it the hard way to increase compatibility...
-        for total, used in re.findall(
-                r"size (\d+\.\d+)GiB used (\d+\.\d+)GiB",
-                btrfs_output,
-                flags=re.MULTILINE
-            ):
-            self._usage['used'] += float(used)
-            self._usage['total'] += float(total)
+        physical_device_used = []
+        physical_device_size = []
+        data_ratios = []
+        for line in btrfs_mount_output:
+            if line.startswith("Used"):
+                physical_device_used.append(float(line.split()[1].rstrip("GiB")))
+            if line.startswith("Device size"):
+                physical_device_size.append(float(line.split()[2].rstrip("GiB")))
+            if line.startswith("Data ratio"):
+                data_ratios.append(float(line.split()[2]))
+        
+        # Divide physical space by the corresponding data ratio to get space 
+        # used for that group.
+        logical_device_used = [x / y for x,y in zip(physical_device_used, data_ratios)]
+        logical_device_size = [x / y for x,y in zip(physical_device_size, data_ratios)]
+        self._usage['total'] += sum(logical_device_size)
+        self._usage['used'] += sum(logical_device_used)

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -9,7 +9,7 @@ from archey.configuration import Configuration
 
 
 class Disk:
-    """Uses `df` command output to compute the total disk usage across devices"""
+    """Uses `df` and `btrfs` commands to compute the total disk usage across devices"""
     def __init__(self):
         # This dictionary will store values obtained from sub-processes calls.
         self._usage = {
@@ -21,7 +21,7 @@ class Disk:
         disk_limits = Configuration().get('limits')['disk']
 
         self._run_df_usage()
-        self._run_btrfs_fi_show()
+        self._run_btrfs_usage()
 
         # Based on the disk percentage usage, select the corresponding threshold color.
         color_selector = bisect(
@@ -61,27 +61,26 @@ class Disk:
         self._usage['used'] += float(df_output[2].rstrip('MB')) / 1024
         self._usage['total'] += float(df_output[1].rstrip('MB')) / 1024
 
-    def _run_btrfs_fi_show(self):
+    def _run_btrfs_usage(self):
         """
-        Since btrfs filesystems can span multiple disks, we fetch all mounted
-        btrfs filesystems, retrieve the btrfs partitions associated with each,
-        and remove all mountpoints with common partitions, then query filesystem
-        usage for each remaining mountpoint.
+        Since btrfs file-systems can span multiple disks, we fetch all mounted
+        btrfs file-systems, retrieve the btrfs partitions associated with each,
+        and remove all mount-points with common partitions, then query file-system
+        usage for each remaining mount-point.
         """
         try:
-            # Retrieve all mountpoints containing btrfs filesystems
-            df_btrfs_output = check_output(
-                ['df', '-l', '-P', '-t', 'btrfs'],
+            # Retrieve all mount-points containing btrfs filesystems.
+            df_btrfs_mounts = check_output(
+                ['df', '-l', '--output=target', '-t', 'btrfs'],
                 env={'LANG': 'C'}, universal_newlines=True, stderr=DEVNULL
             ).splitlines()[1:]
-            btrfs_mounts = [line.split()[5] for line in df_btrfs_output]
         except CalledProcessError:
-            # No btrfs filesystems present.
+            # No btrfs file-systems present.
             return
 
-        # Eliminate duplicate mounts (e.g. different subvolumes)
+        # Eliminate duplicate mounts (e.g. different subvolumes).
         btrfs_unique_mounts = []
-        for mountpoint in btrfs_mounts:
+        for mountpoint in df_btrfs_mounts:
             try:
                 btrfs_mount_output = check_output(
                     ['btrfs', 'device', 'usage', mountpoint],
@@ -90,33 +89,33 @@ class Disk:
             except (FileNotFoundError, CalledProcessError):
                 # `btrfs-progs` not available.
                 return
+
             if btrfs_mount_output not in btrfs_unique_mounts:
                 btrfs_unique_mounts.append(mountpoint)
 
-        # Query all unique mountpoints for usage.
-        btrfs_command = ['btrfs', 'filesystem', 'usage', '-g']
-        btrfs_command.extend(btrfs_unique_mounts)
-        btrfs_mount_output = [
-            line.strip() for line in check_output(
-                btrfs_command, env={'LANG': 'C'}, universal_newlines=True, stderr=DEVNULL
-            ).splitlines()
-        ]
+        # Query all unique mount-points for usage.
+        btrfs_usage_output = check_output(
+            ['btrfs', 'filesystem', 'usage', '--gbytes'] + btrfs_unique_mounts,
+            env={'LANG': 'C'}, universal_newlines=True, stderr=DEVNULL
+        )
+
         # JSON output support landed very "late" in `btrfs-progs` user-space binaries.
         # We are parsing it the hard way to increase compatibility...
         physical_device_used = []
         physical_device_size = []
         data_ratios = []
-        for line in btrfs_mount_output:
+        for line in btrfs_usage_output.splitlines():
+            line = line.strip()
             if line.startswith("Used"):
                 physical_device_used.append(float(line.split()[1].rstrip("GiB")))
-            if line.startswith("Device size"):
+            elif line.startswith("Device size"):
                 physical_device_size.append(float(line.split()[2].rstrip("GiB")))
-            if line.startswith("Data ratio"):
+            elif line.startswith("Data ratio"):
                 data_ratios.append(float(line.split()[2]))
 
-        # Divide physical space by the corresponding data ratio to get space
-        # used for that group.
+        # Divide physical space by the corresponding data ratio to get space used for that group.
         logical_device_used = [x / y for x, y in zip(physical_device_used, data_ratios)]
         logical_device_size = [x / y for x, y in zip(physical_device_size, data_ratios)]
+
         self._usage['total'] += sum(logical_device_size)
         self._usage['used'] += sum(logical_device_used)

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -22,7 +22,7 @@ Filesystem       1000000-blocks    Used Available Capacity Mounted on
 /dev/mapper/home       265741MB 32700MB  219471MB      13% /home
 total                  305809MB 47006MB  243149MB      17% -
 """,
-            FileNotFoundError()  # `btrfs` call will fail.
+            CalledProcessError(1, "df: no file systems processed")  # second `df` call will fail.
         ]
     )
     @patch(
@@ -49,7 +49,7 @@ Filesystem       1000000-blocks     Used Available Capacity Mounted on
 /dev/mapper/home       265741MB 243291MB   22450MB      92% /home
 total                  305809MB 257598MB   46130MB      84% -
 """,
-            FileNotFoundError()  # `btrfs` call will fail.
+            CalledProcessError(1, "df: no file systems processed")  # second `df` call will fail.
         ]
     )
     @patch(
@@ -77,21 +77,59 @@ Filesystem       1000000-blocks    Used Available Capacity Mounted on
 total                  305809MB 47006MB  243149MB      17% -
 """,
             """\
-Label: none  uuid: ac1d4ab8-6ea1-11ea-bc55-0242ac130003
-	Total devices 1 FS bytes used 6.23GiB
-	devid    1 size 55.97GiB used 17.12GiB path /dev/vda1
+Filesystem     1024-blocks      Used  Available Capacity Mounted on
+/dev/nvme0n1p1   499581952 369693476  128527692      75% /
+/dev/sda1       3907016704 620513456 3286302304      16% /vol
+""",
+            """\
+/dev/nvme0n1p1, ID: 1
+   Device size:               0.00B
+   Device slack:              0.00B
+   Unallocated:           476.44GiB
 
-Label: none  uuid: b749f0c6-6ea1-11ea-bc55-0242ac130003
-	Total devices 1 FS bytes used 0.00GiB
-	devid    1 size 3.15GiB used 0.99GiB path /dev/vda8
+""",
+            """\
+/dev/sda1, ID: 1
+   Device size:               0.00B
+   Device slack:              0.00B
+   Unallocated:             3.64TiB
 
-Label: none  uuid: bb675216-6ea1-11ea-bc55-0242ac130003
-	Total devices 1 FS bytes used 0.52GiB
-	devid    1 size 9.37GiB used 2.12GiB path /dev/vda6
+""",
+            """\
+Overall:
+    Device size:                         476.44GiB
+    Device allocated:                    432.02GiB
+    Device unallocated:                   44.42GiB
+    Device missing:                      476.44GiB
+    Used:                                352.13GiB
+    Free (estimated):                    122.57GiB      (min: 122.57GiB)
+    Data ratio:                               1.00
+    Metadata ratio:                           1.00
+    Global reserve:                        0.43GiB      (used: 0.00GiB)
 
-Label: none  uuid: c168c2e4-6ea1-11ea-bc55-0242ac130003
-	Total devices 1 FS bytes used 0.00GiB
-	devid    1 size 9.36GiB used 1.24GiB path /dev/vda7
+Data,single: Size:429.01GiB, Used:350.85GiB (81.78%)
+
+Metadata,single: Size:3.01GiB, Used:1.28GiB (42.56%)
+
+System,single: Size:0.00GiB, Used:0.00GiB (1.95%)
+
+
+Overall:
+    Device size:                        3726.02GiB
+    Device allocated:                    592.01GiB
+    Device unallocated:                 3134.02GiB
+    Device missing:                     3726.02GiB
+    Used:                                591.27GiB
+    Free (estimated):                   1567.03GiB      (min: 1567.03GiB)
+    Data ratio:                               1.00
+    Metadata ratio:                           1.00
+    Global reserve:                        0.50GiB      (used: 0.00GiB)
+
+Data,single: Size:590.00GiB, Used:589.95GiB (99.99%)
+
+Metadata,single: Size:2.00GiB, Used:1.32GiB (66.16%)
+
+System,single: Size:0.01GiB, Used:0.00GiB (1.03%)
 
 """
         ]
@@ -108,13 +146,73 @@ Label: none  uuid: c168c2e4-6ea1-11ea-bc55-0242ac130003
     def test_df_and_btrfs(self, _, __):
         """Test computations around `df` and `btrfs` outputs"""
         disk = Disk().value
-        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '67.4', '376.5']))
+        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '989.3', '4501.1']))
 
     @patch(
         'archey.entries.disk.check_output',
         side_effect=[
             CalledProcessError(1, "df: no file systems processed"),
-            '\n'
+            """\
+Filesystem     1024-blocks      Used  Available Capacity Mounted on
+/dev/nvme0n1p1   499581952 369693476  128527692      75% /
+/dev/sda1       3907016704 620513456 3286302304      16% /vol
+""",
+            """\
+/dev/nvme0n1p1, ID: 1
+   Device size:               0.00B
+   Device slack:              0.00B
+   Unallocated:           476.44GiB
+
+""",
+            """\
+/dev/sda1, ID: 1
+   Device size:               0.00B
+   Device slack:              0.00B
+   Unallocated:             3.64TiB
+
+/dev/sdb1, ID: 2
+   Device size:               0.00B
+   Device slack:              0.00B
+   Unallocated:             3.64TiB
+
+""",
+            """\
+Overall:
+    Device size:                         476.44GiB
+    Device allocated:                    432.02GiB
+    Device unallocated:                   44.42GiB
+    Device missing:                      476.44GiB
+    Used:                                352.13GiB
+    Free (estimated):                    122.57GiB      (min: 122.57GiB)
+    Data ratio:                               1.00
+    Metadata ratio:                           1.00
+    Global reserve:                        0.43GiB      (used: 0.00GiB)
+
+Data,single: Size:429.01GiB, Used:350.85GiB (81.78%)
+
+Metadata,single: Size:3.01GiB, Used:1.28GiB (42.56%)
+
+System,single: Size:0.00GiB, Used:0.00GiB (1.95%)
+
+
+Overall:
+    Device size:                        7452.04GiB
+    Device allocated:                   1184.02GiB
+    Device unallocated:                 6268.03GiB
+    Device missing:                     7452.04GiB
+    Used:                               1182.54GiB
+    Free (estimated):                   3134.06GiB      (min: 3134.06GiB)
+    Data ratio:                               2.00
+    Metadata ratio:                           2.00
+    Global reserve:                        0.50GiB      (used: 0.00GiB)
+
+Data,RAID1: Size:590.00GiB, Used:589.95GiB
+
+Metadata,RAID1: Size:2.00GiB, Used:1.32GiB
+
+System,RAID1: Size:0.01GiB, Used:0.00GiB
+
+"""
         ]
     )
     @patch(
@@ -126,8 +224,29 @@ Label: none  uuid: c168c2e4-6ea1-11ea-bc55-0242ac130003
             }
         }
     )
-    def test_failing_df_and_empty_btrfs(self, _, __):
-        """Test computations around `df` and `btrfs` outputs"""
+    def test_btrfs_only_with_raid_configuration(self, _, __):
+        """Test computations around `btrfs` outputs with a RAID-1 setup"""
+        disk = Disk().value
+        self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '943.4', '4202.5']))
+
+    @patch(
+        'archey.entries.disk.check_output',
+        side_effect=[
+            CalledProcessError(1, "df: no file systems processed"),
+            CalledProcessError(1, "df: no file systems processed")
+        ]
+    )
+    @patch(
+        'archey.entries.disk.Configuration.get',
+        return_value={
+            'disk': {
+                'warning': 50,
+                'danger': 75
+            }
+        }
+    )
+    def test_no_recognised_disks(self, _, __):
+        """Test df failing to detect any valid filesystems"""
         disk = Disk().value
         self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '0.0']))
 

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -77,9 +77,9 @@ Filesystem       1000000-blocks    Used Available Capacity Mounted on
 total                  305809MB 47006MB  243149MB      17% -
 """,
             """\
-Filesystem     1024-blocks      Used  Available Capacity Mounted on
-/dev/nvme0n1p1   499581952 369693476  128527692      75% /
-/dev/sda1       3907016704 620513456 3286302304      16% /vol
+Mounted on
+/
+/vol
 """,
             """\
 /dev/nvme0n1p1, ID: 1
@@ -153,9 +153,9 @@ System,single: Size:0.01GiB, Used:0.00GiB (1.03%)
         side_effect=[
             CalledProcessError(1, "df: no file systems processed"),
             """\
-Filesystem     1024-blocks      Used  Available Capacity Mounted on
-/dev/nvme0n1p1   499581952 369693476  128527692      75% /
-/dev/sda1       3907016704 620513456 3286302304      16% /vol
+Mounted on
+/
+/vol
 """,
             """\
 /dev/nvme0n1p1, ID: 1
@@ -249,6 +249,7 @@ System,RAID1: Size:0.01GiB, Used:0.00GiB
         """Test df failing to detect any valid filesystems"""
         disk = Disk().value
         self.assertTrue(all(i in disk for i in ['\x1b[0;32m', '0.0']))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -86,7 +86,7 @@ fpm \
 	--python-install-bin usr/bin \
 	--python-install-lib usr/lib/python3/dist-packages \
 	--deb-priority 'optional' \
-	--deb-field 'Suggests: dnsutils, lm-sensors, pciutils, wmctrl, virt-what' \
+	--deb-field 'Suggests: dnsutils, lm-sensors, pciutils, wmctrl, virt-what, btrfs-tools' \
 	--deb-no-default-config-files \
 	setup.py
 
@@ -136,6 +136,7 @@ fpm \
 	--pacman-optional-depends 'pciutils: GPU wouldn'"'"'t be detected without it' \
 	--pacman-optional-depends 'wmctrl: WindowManager would be more accurate' \
 	--pacman-optional-depends 'virt-what: Model would contain details about the hypervisor' \
+	--pacman-optional-depends 'btrfs-progs: Disk support for btrfs'
 	setup.py
 
 

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -86,7 +86,7 @@ fpm \
 	--python-install-bin usr/bin \
 	--python-install-lib usr/lib/python3/dist-packages \
 	--deb-priority 'optional' \
-	--deb-field 'Suggests: dnsutils, lm-sensors, pciutils, wmctrl, virt-what, btrfs-tools' \
+	--deb-field 'Suggests: dnsutils, lm-sensors, pciutils, wmctrl, virt-what, btrfs-progs' \
 	--deb-no-default-config-files \
 	setup.py
 
@@ -136,7 +136,7 @@ fpm \
 	--pacman-optional-depends 'pciutils: GPU wouldn'"'"'t be detected without it' \
 	--pacman-optional-depends 'wmctrl: WindowManager would be more accurate' \
 	--pacman-optional-depends 'virt-what: Model would contain details about the hypervisor' \
-	--pacman-optional-depends 'btrfs-progs: Disk support for btrfs'
+	--pacman-optional-depends 'btrfs-progs: Disk would support BTRFS in usage computations' \
 	setup.py
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
This PR allows the inclusion of btrfs filesystems in the disk space module without root, and fixes the behaviour of the btrfs implementation.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
Current behaviour is incorrect for btrfs filesystems:-
* Usage shown is actually allocated space on disk (this allocated space can be larger than the amount of data stored in it, or can be empty if files have been removed)
* Usage and total filesystem space available are counted multiple times for some btrfs configurations, e.g. a RAID-1 setup.
* Root is required to use the current `btrfs-progs` utilities (not ideal!)

## How has this been tested ?
<!--- Include details of your testing environment here -->
* Using the python tests.
* Using two machines with different btrfs configurations.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
