### PR TITLE
[PACKAGING] Fix FPM-based installation location

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
 
-# ################################################################################
+# ##########################################################################################
 #                 Archey 4 distribution packages building script
 #
 # Dependencies :
 # * python3
 # * rpm
+# * bsdtar
 # * debsigs
 # * fpm >= 1.11.0
 # * twine >= 3.1.1
 #
 # Procedure to install them on Debian :
-# $ sudo apt install ruby rubygems build-essential python3-pip debsigs rpm
+# $ sudo apt install ruby rpm build-essential libarchive-tools debsigs rubygems python3-pip
 # $ sudo gem install --no-document fpm
 # $ sudo pip3 install setuptools twine
 #
@@ -22,11 +23,11 @@
 # Known packages errors (FPM bugs ?) :
 # * Debian :
 #     * Lintian : file-in-etc-not-marked-as-conffile etc/archey4/config.json
-#                 This causes the config file to be REMOVED even when NOT PURGING
+#                 This causes the config file to be REMOVED even when NOT PURGING.
 # * Arch Linux :
 #     * `--pacman-optional-depends` appears to be ignored [jordansissel/fpm#1619]
 #
-# ################################################################################
+# ##########################################################################################
 
 
 # Abort on error, don't allow usages of undeclared variable.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
See #59.
Multiple RPMs will now be generated, named as : `archey4-4.Y.Z-R.py3.V.noarch.rpm` (with `V` the second segment of a Python version).
Users will **HAVE TO** pick the correct package according to their Python 3 environment.

## How has this been tested ?
<!--- Include details of your testing environment here -->
Docker containers for each affected distribution.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [ ] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [ ] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
