### PR TITLE
[BUGFIX] Fix crash if no read permissions for /proc/uptime, and use fallbacks instead

### DIFF
--- a/archey/entries/uptime.py
+++ b/archey/entries/uptime.py
@@ -166,7 +166,7 @@ class Uptime(Entry):
             re.VERBOSE
         )
 
-        # Only `days`, `hours` or `minutes` could have been captured.
+        # Only `days`, `hours`, `minutes` or `seconds` could have been captured.
         # `timedelta` directly accepts them as arguments.
         uptime_args = uptime_match.groupdict()
         return timedelta(

--- a/archey/entries/uptime.py
+++ b/archey/entries/uptime.py
@@ -82,7 +82,7 @@ class Uptime(Entry):
         """Tries to get uptime using the `/proc/uptime` file"""
         with open('/proc/uptime') as f_uptime:
             return timedelta(
-                seconds=int(f_uptime.read().split('.')[0])
+                seconds=float(f_uptime.read().split()[0])
             )
 
     @staticmethod

--- a/archey/entries/uptime.py
+++ b/archey/entries/uptime.py
@@ -1,5 +1,12 @@
 """Uptime detection class"""
 
+
+import re
+import time
+import sys
+from datetime import timedelta
+from subprocess import check_output, CalledProcessError
+
 from archey.entry import Entry
 
 
@@ -8,12 +15,14 @@ class Uptime(Entry):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        with open('/proc/uptime') as file:
-            fuptime = int(file.read().split('.')[0])
+        self._uptime = None
+        self._get_uptime()
 
-        day, fuptime = divmod(fuptime, 86400)
-        hour, fuptime = divmod(fuptime, 3600)
-        minute = fuptime // 60
+        self._fuptime = int(self._uptime.total_seconds())
+
+        day, self._fuptime = divmod(self._fuptime, 86400)
+        hour, self._fuptime = divmod(self._fuptime, 3600)
+        minute = self._fuptime // 60
 
         uptime = ''
         if day:
@@ -46,3 +55,112 @@ class Uptime(Entry):
                 uptime = '< 1 minute'
 
         self.value = uptime
+
+    def _get_uptime(self):
+        """Sets `self._uptime` trying a variety of methods"""
+        # Try the /proc/uptime file
+        try:
+            self._proc_file_uptime()
+            return
+        except (PermissionError, FileNotFoundError):
+            # Can't read /proc/uptime, so not Linux or limited permissions.
+            pass
+
+        # Try the python `time` module clocks
+        try:
+            self._clock_uptime()
+            return
+        except RuntimeError:
+            # Probably Python <3.7, or not *NIX
+            pass
+
+        # FUTURE: Windows support could be added here with the `wmi` or `pywin32` module.
+
+        # Fall back to the `uptime` command
+        self._uptime_cmd()
+
+
+    def _proc_file_uptime(self):
+        """Tries to get uptime using the `/proc/uptime` file"""
+        with open('/proc/uptime') as file:
+            self._uptime = timedelta(
+                seconds=int(file.read().split('.')[0])
+            )
+
+    def _clock_uptime(self):
+        """Tries to get uptime using the clocks from the Python `time` module"""
+        # Try: Linux uptime clock, macOS uptime clock, BSD uptime clock.
+        for clock in ['CLOCK_BOOTTIME', 'CLOCK_UPTIME_RAW', 'CLOCK_UPTIME']:
+            try:
+                self._uptime = timedelta(
+                    seconds=time.clock_gettime(getattr(time, clock))
+                )
+                return
+            except AttributeError:
+                pass
+
+        # Probably Python <3.7, or just not one of the above OSes
+        raise RuntimeError
+
+    def _uptime_cmd(self):
+        """Tries to get uptime by parsing the `uptime` command"""
+        try:
+            uptime_output = check_output('uptime')
+        except (CalledProcessError, FileNotFoundError):
+            # No `uptime` command. Since `procps` is a dependency (which provides `uptime`)
+            # we can just exit here.
+            sys.exit('Required dependency `procps` (or `procps-ng`) missing. Please install.')
+
+        # Unfortunately the output is not designed to be machine-readable...
+        uptime_match = re.search(
+            r"""
+            up\s+?             # match the `up` preceding the uptime, anchors the start of the regex
+            (?:                # non-capture group for days
+               (?P<days>       # 'days' named capture group, captures the days digits
+                  \d+?
+               )
+               \s+?            # match whitespace,
+               day[s]?         # 'day' or 'days',
+               [,\s]+?         # then a comma (if present) followed by more whitespace
+            )?                 # match the days non-capture group 0 or 1 times
+            (?:                # non-capture group for hours & minutes
+               (?:             # non-capture group for just hours
+                  (?P<hours>   # 'hours' named capture group, captures the hours digits
+                     \d+?
+                  )
+                  (?:          # non-capture group for hours:minutes colon or 'hrs' text
+                     :         # i.e. hours followed by either a single colon
+                     |         # OR
+                     \s+?hrs   # one or more whitespace chars non-greedily, followed by 'hrs'
+                  )
+               )?              # match the hours non-capture group 0 or 1 times
+               (?:             # non-capture group for minutes
+                  (?P<minutes> # 'minutes' named capture group, captures the minutes digits
+                     \d+?
+                  )
+                  (?:          # non-capture group for 'min' or 'mins' text
+                     \s+?      # match whitespace,
+                     min[s]?   # followed by 'min' or 'mins
+                  )?           # match the 'mins' text non-capture group 0 or 1 times,
+               )?              # the minutes non-capture group 0 or 1 times
+            )?                 # and the entire hours & minutes non-capture group 0 or 1 times
+            [,\s]*?            # followed by a comma and/or whitespace,
+            \d+?               # some digits for the user count,
+            \s+?               # whitespace between the user count and the text 'user',
+            user               # and the text 'user' - this is to anchor the end of the expression.
+            """,
+            uptime_output,
+            re.VERBOSE
+        )
+
+        times_dict = uptime_match.groupdict()
+        timedelta_args = {
+            'days': 0,
+            'minutes': 0,
+            'hours': 0
+        }
+        for time_unit, value in times_dict.items():
+            if value is not None:
+                timedelta_args[time_unit] = int(value)
+
+        self._uptime = timedelta(**timedelta_args)

--- a/archey/entries/uptime.py
+++ b/archey/entries/uptime.py
@@ -108,6 +108,7 @@ class Uptime(Entry):
         except FileNotFoundError:
             # No `uptime` command.
             # Since `procps` is a dependency (which provides `uptime`) we can just exit here.
+            # Note: We shouldn't get there as `Processes` depends on `procps` beforehand.
             sys.exit("Please, install first `procps` (or `procps-ng`) on your system.")
 
         # Unfortunately the output is not designed to be machine-readable...

--- a/archey/entries/uptime.py
+++ b/archey/entries/uptime.py
@@ -108,7 +108,6 @@ class Uptime(Entry):
         except FileNotFoundError:
             # No `uptime` command.
             # Since `procps` is a dependency (which provides `uptime`) we can just exit here.
-            # Note: We _should_ not got there as `Processes` first check `procps` availability.
             sys.exit("Please, install first `procps` (or `procps-ng`) on your system.")
 
         # Unfortunately the output is not designed to be machine-readable...
@@ -131,7 +130,7 @@ class Uptime(Entry):
                   (?:          # non-capture group for hours:minutes colon or 'hrs' text
                      :         # i.e. hours followed by either a single colon
                      |         # OR
-                     \s+?hrs   # one or more whitespace chars non-greedily, followed by 'hrs'
+                     \s+?hrs?  # one or more whitespace chars non-greedily followed by 'hr' or 'hrs'
                   )
                )?              # match the hours non-capture group 0 or 1 times
                (?:             # non-capture group for minutes
@@ -140,7 +139,7 @@ class Uptime(Entry):
                   )
                   (?:          # non-capture group for 'min' or 'mins' text
                      \s+?      # match whitespace,
-                     mins?     # followed by 'min' or 'mins
+                     mins?     # followed by 'min' or 'mins'
                   )?           # match the 'mins' text non-capture group 0 or 1 times,
                )?              # the minutes non-capture group 0 or 1 times
             )?                 # and the entire hours & minutes non-capture group 0 or 1 times

--- a/archey/processes.py
+++ b/archey/processes.py
@@ -29,11 +29,7 @@ class Processes(metaclass=Singleton):
                 universal_newlines=True
             ).splitlines()[1:]
         except FileNotFoundError:
-            print(
-                "Please, install first `procps` on your distribution.",
-                file=sys.stderr
-            )
-            sys.exit(1)
+            sys.exit("Please, install first `procps` (or `procps-ng`) on your system.")
 
     def get(self):
         """Simple getter to retrieve the processes list"""

--- a/archey/test/test_archey_uptime.py
+++ b/archey/test/test_archey_uptime.py
@@ -84,7 +84,7 @@ class TestUptimeEntry(unittest.TestCase):
     def test_clock_fallback(self, _, __, ___):
         """
         Test when we can't access /proc/uptime on Linux/macOS/BSD.
-        We only test one clock as all clocks rely on the same builtin `time.clock_gettime` method.
+        We only test one clock as all clocks rely on the same built-in `time.clock_gettime` method.
         """
         self.assertEqual(Uptime().value, '16 minutes')
 
@@ -100,50 +100,50 @@ class TestUptimeEntry(unittest.TestCase):
         # pylint: disable=line-too-long
         test_uptime_cases = {
             # Recently booted:
-            '{time} up 0 sec, {user_loadavg}': timedelta(seconds=0), # BSD, just booted
-            '{time} up 1 sec, {user_loadavg}': timedelta(seconds=1), # BSD, < 1 min uptime
-            '{time} up 12 secs, {user_loadavg}': timedelta(seconds=12), # BSD, < 1 min uptime
-            '{time} up 0 min, {user_loadavg}': timedelta(minutes=0), # Linux, < 1 min uptime
+            '{time} up 0 sec, {user_loadavg}': timedelta(seconds=0),  # BSD, just booted
+            '{time} up 1 sec, {user_loadavg}': timedelta(seconds=1),  # BSD, < 1 min uptime
+            '{time} up 12 secs, {user_loadavg}': timedelta(seconds=12),  # BSD, < 1 min uptime
+            '{time} up 0 min, {user_loadavg}': timedelta(minutes=0),  # Linux, < 1 min uptime
             '{time} up 1 min, {user_loadavg}': timedelta(minutes=1),
             # 1 min to 1 day
             '{time} up 12 mins, {user_loadavg}': timedelta(minutes=12),
-            '{time} up 12 min, {user_loadavg}': timedelta(minutes=12), # Variation without plural minutes
+            '{time} up 12 min, {user_loadavg}': timedelta(minutes=12),  # Variation without plural minutes
             '{time} up 1:00, {user_loadavg}': timedelta(hours=1),
             '{time} up 1:01, {user_loadavg}': timedelta(hours=1, minutes=1),
             '{time} up 1:23, {user_loadavg}': timedelta(hours=1, minutes=23),
             '{time} up 12:34, {user_loadavg}': timedelta(hours=12, minutes=34),
             # 1 day to 2 days
-            '{time} up 1 day, 0 sec, {user_loadavg}': timedelta(days=1), # BSD
-            '{time} up 1 day, 1 sec, {user_loadavg}': timedelta(days=1, seconds=1), # BSD
-            '{time} up 1 day, 12 secs, {user_loadavg}': timedelta(days=1, seconds=12), # BSD
-            '{time} up 1 day, 0 min, {user_loadavg}': timedelta(days=1), # Linux
+            '{time} up 1 day, 0 sec, {user_loadavg}': timedelta(days=1),  # BSD
+            '{time} up 1 day, 1 sec, {user_loadavg}': timedelta(days=1, seconds=1),  # BSD
+            '{time} up 1 day, 12 secs, {user_loadavg}': timedelta(days=1, seconds=12),  # BSD
+            '{time} up 1 day, 0 min, {user_loadavg}': timedelta(days=1),  # Linux
             '{time} up 1 day, 1 min, {user_loadavg}': timedelta(days=1, minutes=1),
             '{time} up 1 day, 12 mins, {user_loadavg}': timedelta(days=1, minutes=12),
-            '{time} up 1 day, 12 min, {user_loadavg}': timedelta(days=1, minutes=12), # Variation without plural minutes
+            '{time} up 1 day, 12 min, {user_loadavg}': timedelta(days=1, minutes=12),  # Variation without plural minutes
             '{time} up 1 day, 1:00, {user_loadavg}': timedelta(days=1, hours=1),
             '{time} up 1 day, 1:01, {user_loadavg}': timedelta(days=1, hours=1, minutes=1),
             '{time} up 1 day, 1:23, {user_loadavg}': timedelta(days=1, hours=1, minutes=23),
             '{time} up 1 day, 12:34, {user_loadavg}': timedelta(days=1, hours=12, minutes=34),
             # 2 days onwards
-            '{time} up 12 days, 0 sec, {user_loadavg}': timedelta(days=12), # BSD
-            '{time} up 12 days, 1 sec, {user_loadavg}': timedelta(days=12, seconds=1), # BSD
-            '{time} up 12 days, 12 secs, {user_loadavg}': timedelta(days=12, seconds=12), # BSD
-            '{time} up 12 days, 0 min, {user_loadavg}': timedelta(days=12), # Linux
+            '{time} up 12 days, 0 sec, {user_loadavg}': timedelta(days=12),  # BSD
+            '{time} up 12 days, 1 sec, {user_loadavg}': timedelta(days=12, seconds=1),  # BSD
+            '{time} up 12 days, 12 secs, {user_loadavg}': timedelta(days=12, seconds=12),  # BSD
+            '{time} up 12 days, 0 min, {user_loadavg}': timedelta(days=12),  # Linux
             '{time} up 12 days, 1 min, {user_loadavg}': timedelta(days=12, minutes=1),
             '{time} up 12 days, 12 mins, {user_loadavg}': timedelta(days=12, minutes=12),
-            '{time} up 12 day, 12 min, {user_loadavg}': timedelta(days=12, minutes=12), # Variation without plural minutes
+            '{time} up 12 day, 12 min, {user_loadavg}': timedelta(days=12, minutes=12),  # Variation without plural minutes
             '{time} up 12 days, 1:00, {user_loadavg}': timedelta(days=12, hours=1),
             '{time} up 12 days, 1:01, {user_loadavg}': timedelta(days=12, hours=1, minutes=1),
             '{time} up 12 days, 1:23, {user_loadavg}': timedelta(days=12, hours=1, minutes=23),
             '{time} up 12 days, 12:34, {user_loadavg}': timedelta(days=12, hours=12, minutes=34),
             # Very long uptimes - sanity check :)
-            '{time} up 500 days, 0 sec, {user_loadavg}': timedelta(days=500), # BSD
-            '{time} up 500 days, 1 sec, {user_loadavg}': timedelta(days=500, seconds=1), # BSD
-            '{time} up 500 days, 12 secs, {user_loadavg}': timedelta(days=500, seconds=12), # BSD
-            '{time} up 500 days, 0 min, {user_loadavg}': timedelta(days=500), # Linux
+            '{time} up 500 days, 0 sec, {user_loadavg}': timedelta(days=500),  # BSD
+            '{time} up 500 days, 1 sec, {user_loadavg}': timedelta(days=500, seconds=1),  # BSD
+            '{time} up 500 days, 12 secs, {user_loadavg}': timedelta(days=500, seconds=12),  # BSD
+            '{time} up 500 days, 0 min, {user_loadavg}': timedelta(days=500),  # Linux
             '{time} up 500 days, 1 min, {user_loadavg}': timedelta(days=500, minutes=1),
             '{time} up 500 days, 12 mins, {user_loadavg}': timedelta(days=500, minutes=12),
-            '{time} up 500 day, 12 min, {user_loadavg}': timedelta(days=500, minutes=12), # Variation without plural minutes
+            '{time} up 500 day, 12 min, {user_loadavg}': timedelta(days=500, minutes=12),  # Variation without plural minutes
             '{time} up 500 days, 1:00, {user_loadavg}': timedelta(days=500, hours=1),
             '{time} up 500 days, 1:01, {user_loadavg}': timedelta(days=500, hours=1, minutes=1),
             '{time} up 500 days, 1:23, {user_loadavg}': timedelta(days=500, hours=1, minutes=23),
@@ -154,28 +154,28 @@ class TestUptimeEntry(unittest.TestCase):
         # Variations of the time in the `{time}` section.
         # These _should_ be avoided when we set the locale in `check_output`,
         # however let's check we can handle them anyway, just in case.
-        time_variations = [
+        time_variations = (
             '0:00', '9:43 ', '11:37  ', '19:21', '23:59',
             '12:00am', '1:10am', '1:10pm ', '6:43pm ', '8:26am ',
             '03:14:15', '09:26:12 ', '23:19:20  ',
             'nonsense_time  ', 'hopefully_works_anyway ',
             '  even with strange spacing!'
-        ]
+        )
 
         # Variations of the user count and load average section.
         # For this, we'll just combine user variations with a few load average variations.
-        user_variations = [
+        user_variations = (
             '1 user ', '1 user  ', ' 1 user, ', ' 1 user,  ',
             '2 users ', '2 users  ', '  2 users, ', '  2 users,  ',
             '15 users ', '15 users  ', ' 15 users, ', ' 15 users,  ',
             '150 users ', '150 users  ', '150 users, ', '150 users,  ',
-        ]
-        loadavg_variations = [
+        )
+        loadavg_variations = (
             'load averages: 1.95 1.28 2.10',
             'load average: 0.13, 0.17, 0.13',
             'we never match this part so the content here',
             '  should not affect our parsing'
-        ]
+        )
         user_loadavg_variations = [
             user + loadavg
             for user in user_variations
@@ -191,7 +191,7 @@ class TestUptimeEntry(unittest.TestCase):
                     user_loadavg=variations[1]
                 )
                 self.assertEqual(
-                    uptime_inst._parse_uptime_cmd(), # pylint: disable=protected-access
+                    uptime_inst._parse_uptime_cmd(),  # pylint: disable=protected-access
                     expected_delta,
                     msg='`uptime` output: "{0}"'.format(
                         uptime_output.format(
@@ -218,8 +218,7 @@ class TestUptimeEntry(unittest.TestCase):
     )
     def test_procps_missing(self, _, __, ___):
         """Test `uptime` failure when no uptime sources are available"""
-        with self.assertRaises(SystemExit):
-            Uptime()
+        self.assertRaises(SystemExit, Uptime)
 
 
 if __name__ == '__main__':

--- a/archey/test/test_archey_uptime.py
+++ b/archey/test/test_archey_uptime.py
@@ -2,6 +2,7 @@
 
 import unittest
 from unittest.mock import mock_open, patch
+from datetime import timedelta
 
 from archey.entries.uptime import Uptime
 
@@ -62,8 +63,74 @@ class TestUptimeEntry(unittest.TestCase):
         create=True
     )
     def test_days_and_minutes(self):
-        """Test when only days ABD minutes should be displayed"""
+        """Test when only days AND minutes should be displayed"""
         self.assertEqual(Uptime().value, '3 days and 3 minutes')
+
+    @patch(
+        'archey.entries.uptime.open',
+        side_effect=PermissionError(),
+        create=True
+    )
+    # We patch in Linux's CLOCK_BOOTTIME to ensure that
+    # the `getattr` call before `clock_gettime` succeeds
+    @patch(
+        'archey.entries.uptime.time.CLOCK_BOOTTIME',
+        create=True
+    )
+    @patch(
+        'archey.entries.uptime.time.clock_gettime',
+        return_value=1000,
+        create=True
+    )
+    def test_clock_fallback(self, _, __, ___):
+        """
+        Test when we can't access /proc/uptime on Linux/macOS/BSD
+        We only test one clock as all clocks rely on the same builtin `time.clock_gettime` method.
+        """
+        self.assertEqual(Uptime().value, '16 minutes')
+
+    @patch(
+        'archey.entries.uptime.check_output'
+    )
+    def test_linux_clock_fallback(self, check_output_mock):
+        """Test `uptime` command parsing"""
+        # Create an uptime instance to perform testing
+        # It doesn't matter that this will run its __init__
+        uptime_inst = Uptime()
+
+        # Keys: `uptime` outputs; values: expected time deltas.
+        # These outputs have been gathered from various *NIX sytems.
+        # pragma pylint: disable=line-too-long
+        test_cases = {
+            '19:52  up 14 mins, 2 users, load averages: 2.95 4.19 4.31': timedelta(minutes=14),
+            '8:03 up 52 days, 20:47, 3 users, load averages: 1.36 1.42 1.40': timedelta(days=52, hours=20, minutes=47),
+            '22:19 up 54 days, 1 min, 4 users, load averages: 2.08 2.06 2.27': timedelta(days=54, minutes=1),
+            '11:53  up  3:02, 2 users, load averages: 0,32 0,34 0,43': timedelta(hours=3, minutes=2),
+            '12:55pm  up 105 days, 21 hrs,  2 users,  load average: 0.26, 0.26, 0.26': timedelta(days=105, hours=21),
+            '1:41pm  up 105 days, 21:46,  2 users,  load average: 0.28, 0.28, 0.27': timedelta(days=105, hours=21, minutes=46),
+            '8:27  up 1 day, 17:06, 1 user, load averages: 1,01 0,87 0,79': timedelta(days=1, hours=17, minutes=6),
+            '06:27:33 up 4 days,  2:36,  2 users,  load average: 0.16, 0.26, 0.27': timedelta(days=4, hours=2, minutes=36),
+            '06:28:26 up 54 min,  127 users,  load average: 6.34, 6.28, 6.27': timedelta(minutes=54),
+            '17:35pm  up 5 days  9:24,  9 users,  load average: 0.30, 0.28, 0.28': timedelta(days=5, hours=9, minutes=24),
+            '17:36:15 up  8:44,  2 users,  load average: 0.09, 0.30, 0.41': timedelta(hours=8, minutes=44),
+            '03:14:20 up 1 min,  2 users,  load average: 2.28, 1.29, 0.50': timedelta(minutes=1),
+            '04:12:29 up 59 min,  5 users,  load average: 0.06, 0.08, 0.48': timedelta(minutes=59),
+            '05:14:09 up  2:01,  5 users,  load average: 0.13, 0.10, 0.45': timedelta(hours=2, minutes=1),
+            '03:13:19 up 1 day, 0 min,  8 users,  load average: 0.01, 0.04, 0.05': timedelta(days=1),
+            '04:13:19 up 1 day,  1:00,  8 users,  load average: 0.02, 0.05, 0.21': timedelta(days=1, hours=1),
+            '12:49:10 up 25 days, 21:30, 28 users,  load average: 0.50, 0.66, 0.52': timedelta(days=25, hours=21, minutes=30)
+        }
+        # pragma pylint: enable=line-too-long
+
+        for uptime_output, expected_delta in test_cases.items():
+            check_output_mock.return_value = uptime_output
+            uptime_inst._uptime_cmd() # pylint: disable=protected-access
+
+            self.assertEqual(
+                uptime_inst._uptime, # pylint: disable=protected-access
+                expected_delta,
+                msg='`uptime` output: {0}'.format(uptime_output)
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
On some systems without read permissions on `/proc/uptime` (e.g. Android), or lacking `/proc/uptime` (BSD) Archey will fail with a traceback. This PR fixes this bug and adds additional fallback detections to the Uptime entry to support these systems.

## Description
Reworked the uptime entry somewhat to now try a few methods of detecting uptime, hopefully preventing complete failure with a traceback.
The uptime is now found as follows:
* Try reading /proc/uptime
* Try using the clocks provided by Python's `time` module for Linux, macOS and BSD.
* Try parsing the `uptime` command (from `procps`(`-ng`)

Added test cases for this new behaviour, as well as getting `uptime` output from various systems and making sure these are all handled correctly.

## How has this been tested ?
Using the test cases with various different systems' behaviour, and on my local machine as usual 😃 


## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).

(I removed the unneeded checklist items so our PR progress bar is somewhat meaningful 😃)