### PR TITLE
[WIP] Disk entry rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,25 +194,26 @@ Below, some further explanations of each option available :
 		// `["local"]` shows only local filesystems.
 		// You can alternatively list specific filesystems as:
 		//  * A list of device paths - e.g. `["/dev/sda1", "/dev/nvme0n1p1"]`
-		//  * A list of mountpoints - e.g. `["/", "/mnt"]`
+		//  * A list of mount points - e.g. `["/", "/mnt"]`
 		//  * A combination of the above - e.g. `["/", "/dev/sda2"]`
 		"show_filesystems": ["local"],
 		// Set to `false` to write each filesystem on its own line.
 		"combine_total": true,
 		// Defines which labels to use for each disk (only works if `combine_total` is false!)
 		// The options available are:
-		//  * `"mount_points"`: Shows the mountpoint of the filesystem.
+		//  * `"mount_points"`: Shows the mount point of the filesystem.
 		//      e.g. `Disk (/): 10.0 GiB/100.0 GiB`
 		//           `Disk (/mnt): 15.0 GiB / 200.0 GiB`
 		//  * `"device_paths"`: Shows the device path of the filesystem.
 		//      e.g. `Disk (/dev/sda1): 10.0 GiB / 100.0 GiB`
 		//           `Disk (/dev/mmcblk0p1): 15.0 GiB / 200.0 GiB`
-		//  * `false` (no quote marks!): Don't show any device labels.
+		//  * `false` or `null` (no quote marks!): Don't show any device labels.
 		//      e.g. `Disk: 10.0 GiB / 100.0 GiB`
 		//           `Disk: 15.0 GiB / 200.0 GiB`
 		"disk_labels": null,
 		// Set to `true` to hide the "Disk" entry name from the output.
-		// i.e. false --> `Disk (/):`
+		// i.e. null  --> `Disk (/):`
+		//      false --> `Disk (/):`
 		//      true  --> `(/):`
 		"hide_entry_name": null
 	},

--- a/README.md
+++ b/README.md
@@ -189,6 +189,33 @@ Below, some further explanations of each option available :
 		// `true` by default to honor `os-release`'s `ANSI_COLOR` option.
 		"honor_ansi_color": true
 	},
+	"disk": {
+		// Which filesystems to show:
+		// `["local"]` shows only local filesystems.
+		// You can alternatively list specific filesystems as:
+		//  * A list of device paths - e.g. `["/dev/sda1", "/dev/nvme0n1p1"]`
+		//  * A list of mountpoints - e.g. `["/", "/mnt"]`
+		//  * A combination of the above - e.g. `["/", "/dev/sda2"]`
+		"show_filesystems": ["local"],
+		// Set to `false` to write each filesystem on its own line.
+		"combine_disks": true,
+		// Defines which labels to use for each disk (only works if `combine_disks` is false!)
+		// The options available are:
+		//  * `"mountpoints"`: Shows the mountpoint of the filesystem.
+		//      e.g. `Disk (/): 10.0 GiB/100.0 GiB`
+		//           `Disk (/mnt): 15.0 GiB / 200.0 GiB`
+		//  * `"device_paths"`: Shows the device path of the filesystem.
+		//      e.g. `Disk (/dev/sda1): 10.0 GiB / 100.0 GiB`
+		//           `Disk (/dev/mmcblk0p1): 15.0 GiB / 200.0 GiB`
+		//  * `false` (no quote marks!): Don't show any device labels.
+		//      e.g. `Disk: 10.0 GiB / 100.0 GiB`
+		//           `Disk: 15.0 GiB / 200.0 GiB`
+		"disk_labels": "mountpoints",
+		// Set to `true` to hide the "Disk" entry name from the output.
+		// i.e. false --> `Disk (/):`
+		//      true  --> `(/):`
+		"hide_entry_name": false
+	}
 	"default_strings": {
 		// Use this section to override default strings.
 	},

--- a/README.md
+++ b/README.md
@@ -50,14 +50,13 @@ The answer is [here](https://blog.samuel.domains/archey4).
 
 ### Highly recommended packages
 
-|     Environments      |              Packages               |                       Reasons                        |            Notes             |
-| :-------------------- | :---------------------------------- | :--------------------------------------------------- | :--------------------------- |
-| All                   | `dnsutils` (maybe `bind-tools`)     | **WAN\_IP** would be detected faster                 | Would provide `dig`          |
-| All                   | `lm-sensors` (maybe `lm_sensors`)   | **Temperature** would be more accurate               | N/A                          |
-| Graphical (desktop)   | `pciutils`                          | **GPU** wouldn't be detected without it              | Would provide `lspci`        |
-| Graphical (desktop)   | `wmctrl`                            | **WindowManager** would be more accurate             | N/A                          |
-| Virtual w/o `systemd` | `virt-what` and `dmidecode`         | **Model** would contain details about the hypervisor | **root** privileges required |
-| BTRFS file-systems    | `btrfs-progs` (maybe `btrfs-tools`) | **Disk** would support BTRFS in usage computations   | N/A                          |
+|     Environments      |             Packages              |                       Reasons                        |            Notes             |
+| :-------------------- | :-------------------------------- | :--------------------------------------------------- | :--------------------------- |
+| All                   | `dnsutils` (maybe `bind-tools`)   | **WAN\_IP** would be detected faster                 | Would provide `dig`          |
+| All                   | `lm-sensors` (maybe `lm_sensors`) | **Temperature** would be more accurate               | N/A                          |
+| Graphical (desktop)   | `pciutils`                        | **GPU** wouldn't be detected without it              | Would provide `lspci`        |
+| Graphical (desktop)   | `wmctrl`                          | **WindowManager** would be more accurate             | N/A                          |
+| Virtual w/o `systemd` | `virt-what` and `dmidecode`       | **Model** would contain details about the hypervisor | **root** privileges required |
 
 ### :warning: Various notes to read before going down :warning:
 

--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ Below, some further explanations of each option available :
 		//  * A combination of the above - e.g. `["/", "/dev/sda2"]`
 		"show_filesystems": ["local"],
 		// Set to `false` to write each filesystem on its own line.
-		"combine_disks": true,
-		// Defines which labels to use for each disk (only works if `combine_disks` is false!)
+		"combine_total": true,
+		// Defines which labels to use for each disk (only works if `combine_total` is false!)
 		// The options available are:
-		//  * `"mountpoints"`: Shows the mountpoint of the filesystem.
+		//  * `"mount_points"`: Shows the mountpoint of the filesystem.
 		//      e.g. `Disk (/): 10.0 GiB/100.0 GiB`
 		//           `Disk (/mnt): 15.0 GiB / 200.0 GiB`
 		//  * `"device_paths"`: Shows the device path of the filesystem.
@@ -210,12 +210,12 @@ Below, some further explanations of each option available :
 		//  * `false` (no quote marks!): Don't show any device labels.
 		//      e.g. `Disk: 10.0 GiB / 100.0 GiB`
 		//           `Disk: 15.0 GiB / 200.0 GiB`
-		"disk_labels": "mountpoints",
+		"disk_labels": null,
 		// Set to `true` to hide the "Disk" entry name from the output.
 		// i.e. false --> `Disk (/):`
 		//      true  --> `(/):`
-		"hide_entry_name": false
-	}
+		"hide_entry_name": null
+	},
 	"default_strings": {
 		// Use this section to override default strings.
 	},

--- a/archey/config.json
+++ b/archey/config.json
@@ -25,6 +25,12 @@
 		"use_unicode": false,
 		"honor_ansi_color": true
 	},
+	"disk": {
+		"show_filesystems": ["local"],
+		"combine_disks": true,
+		"disk_labels": false,
+		"hide_entry_name": true
+	},
 	"default_strings": {
 		"no_address": "No Address",
 		"not_detected": "Not detected",

--- a/archey/config.json
+++ b/archey/config.json
@@ -27,9 +27,9 @@
 	},
 	"disk": {
 		"show_filesystems": ["local"],
-		"combine_disks": true,
-		"disk_labels": false,
-		"hide_entry_name": true
+		"combine_total": true,
+		"disk_labels": null,
+		"hide_entry_name": null
 	},
 	"default_strings": {
 		"no_address": "No Address",

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -21,9 +21,9 @@ class Configuration(metaclass=Singleton):
             },
             'disk': {
                 'show_filesystems': ['local'],
-                'combine_disks': True,
-                'disk_labels': False,
-                'hide_entry_name': False
+                'combine_total': True,
+                'disk_labels': None,
+                'hide_entry_name': None
             },
             'default_strings': {
                 'no_address': 'No Address',

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -19,6 +19,12 @@ class Configuration(metaclass=Singleton):
                 'use_unicode': False,
                 'honor_ansi_color': True
             },
+            'disk': {
+                'show_filesystems': ['local'],
+                'combine_disks': True,
+                'disk_labels': False,
+                'hide_entry_name': False
+            },
             'default_strings': {
                 'no_address': 'No Address',
                 'not_detected': 'Not detected',

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -162,7 +162,7 @@ class Disk(Entry):
         disk_labels = self._configuration.get('disk')['disk_labels']
         hide_entry_name = self._configuration.get('disk')['hide_entry_name']
 
-        # Combine all disks into one grand-total if configured to do so.
+        # Combine all entries into one grand-total if configured to do so.
         if self._configuration.get('disk')['combine_total']:
             name = self.name
 
@@ -181,9 +181,10 @@ class Disk(Entry):
                 }
             }
         else:
-            # We will only use disk labels and entry name hiding if we aren't combining disks.
+            # We will only use disk labels and entry name hiding if we aren't combining entries.
             name = ''
-            if not hide_entry_name:
+            # Hide `Disk` from entry name only if the user specified it... as long as a label.
+            if not hide_entry_name or not disk_labels:
                 name += self.name
             if disk_labels:
                 if not hide_entry_name:
@@ -193,7 +194,7 @@ class Disk(Entry):
         # Fetch the user-defined limits from the configuration.
         disk_limits = self._configuration.get('limits')['disk']
 
-        # We will only run this loop a single time for combined disks.
+        # We will only run this loop a single time for combined entries.
         for mount_point, filesystem_data in filesystems.items():
             # Select the corresponding level color based on disk percentage usage.
             level_color = Colors.get_level_color(

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -5,297 +5,67 @@ from subprocess import CalledProcessError
 import unittest
 from unittest.mock import patch, MagicMock
 
-from archey.entries.disk import Disk
 from archey.colors import Colors
+from archey.entries.disk import Disk
 
 
 class TestDiskEntry(unittest.TestCase):
     """
     Here, we mock `check_output` calls to disk utility tools.
     """
-    @patch(
-        'archey.entries.disk.check_output',
-        side_effect=[
-            """\
-Filesystem       1000000-blocks    Used Available Capacity Mounted on
-/dev/mapper/root        39101MB 14216MB   22870MB      39% /
-/dev/sda1                 967MB    91MB     810MB      11% /boot
-/dev/mapper/home       265741MB 32700MB  219471MB      13% /home
-total                  305809MB 47006MB  243149MB      17% -
-""",
-            # Second `df` call will fail.
-            CalledProcessError(1, 'df', "df: no file systems processed\n")
-        ]
-    )
-    @patch(
-        'archey.configuration.Configuration.get',
-        return_value={
+    def setUp(self):
+        """Some useful setup tasks to do before each test, to help us DRY."""
+        self.disk_instance_mock = MagicMock(spec=Disk, wraps=Disk)
+        self.output_mock = MagicMock()
+        # Let's set `Disk` instance mock's attributes to sensible defaults.
+        self.disk_instance_mock.name = 'Disk'
+        self.disk_instance_mock.value = None
+        # We can always change this configuration in tests if need be.
+        self.disk_instance_mock._configuration = {  # pylint: disable=protected-access
             'disk': {
-                'warning': 50,
-                'danger': 75
-            }
+                'show_filesystems': ['local'],
+                'combine_total': True,
+                'disk_labels': None,
+                'hide_entry_name': None
+            },
+            'limits': {
+                'disk': {
+                    'warning': 50,
+                    'danger': 75
+                }
+            },
+            # Required by all entries:
+            'default_strings': {'not_detected': 'Not detected'}
         }
-    )
-    def test_df_only(self, _, __):
-        """Test computations around `df` output at disk regular level"""
-        output_mock = MagicMock()
-        Disk().output(output_mock)
-        self.assertEqual(
-            output_mock.append.call_args[0][1],
-            '{0}45.9 GiB{1} / 298.6 GiB'.format(
-                Colors.GREEN_NORMAL,
-                Colors.CLEAR
-            )
-        )
 
-    @patch(
-        'archey.entries.disk.check_output',
-        side_effect=[
-            """\
-Filesystem       1000000-blocks     Used Available Capacity Mounted on
-/dev/mapper/root        39101MB  14216MB   22870MB      39% /
-/dev/sda1                 967MB     91MB     810MB      11% /boot
-/dev/mapper/home       265741MB 243291MB   22450MB      92% /home
-total                  305809MB 257598MB   46130MB      84% -
-""",
-            # Second `df` call will fail.
-            CalledProcessError(1, 'df', "df: no file systems processed\n")
-        ]
-    )
-    @patch(
-        'archey.configuration.Configuration.get',
-        return_value={
-            'disk': {
-                'warning': 80,
-                'danger': 90
-            }
+
+    def test_disk_output_colors(self):
+        """Test `output` disk level coloring."""
+        # This dict's values are tuples of used blocks, and the level's corresponding color.
+        # For reference, this test uses a disk whose total block count is 100.
+        levels = {
+            'normal': (45, Colors.GREEN_NORMAL),
+            'warning': (70, Colors.YELLOW_NORMAL),
+            'danger': (95, Colors.RED_NORMAL)
         }
-    )
-    def test_df_only_warning(self, _, __):
-        """Test computations around `df` output at disk warning level"""
-        output_mock = MagicMock()
-        Disk().output(output_mock)
-        self.assertEqual(
-            output_mock.append.call_args[0][1],
-            '{0}251.6 GiB{1} / 298.6 GiB'.format(
-                Colors.YELLOW_NORMAL,
-                Colors.CLEAR
-            )
-        )
-
-    @patch(
-        'archey.entries.disk.check_output',
-        side_effect=[
-            """\
-Filesystem       1000000-blocks     Used Available Capacity Mounted on
-/dev/mapper/root        39101MB  14216MB   22870MB      39% /
-/dev/sda1                 967MB     91MB     810MB      11% /boot
-/dev/mapper/home       265741MB 243291MB   22450MB      92% /home
-total                  305809MB 257598MB   46130MB      84% -
-""",
-            # Second `df` call will fail.
-            CalledProcessError(1, 'df', "df: no file systems processed\n")
-        ]
-    )
-    @patch(
-        'archey.configuration.Configuration.get',
-        return_value={
-            'disk': {
-                'warning': 50,
-                'danger': 80
-            }
-        }
-    )
-    def test_df_only_danger(self, _, __):
-        """Test computations around `df` output at disk danger level"""
-        output_mock = MagicMock()
-        Disk().output(output_mock)
-        self.assertEqual(
-            output_mock.append.call_args[0][1],
-            '{0}251.6 GiB{1} / 298.6 GiB'.format(
-                Colors.RED_NORMAL,
-                Colors.CLEAR
-            )
-        )
-
-    @patch(
-        'archey.entries.disk.check_output',
-        side_effect=[
-            """\
-Filesystem       1000000-blocks    Used Available Capacity Mounted on
-/dev/mapper/root        39101MB 14216MB   22870MB      39% /
-/dev/sda1                 967MB    91MB     810MB      11% /boot
-/dev/mapper/home       265741MB 32700MB  219471MB      13% /home
-total                  305809MB 47006MB  243149MB      17% -
-""",
-            """\
-Mounted on
-/
-/vol
-""",
-            """\
-/dev/nvme0n1p1, ID: 1
-   Device size:               0.00B
-   Device slack:              0.00B
-   Unallocated:           476.44GiB
-
-""",
-            """\
-/dev/sda1, ID: 1
-   Device size:               0.00B
-   Device slack:              0.00B
-   Unallocated:             3.64TiB
-
-""",
-            """\
-Overall:
-    Device size:                         476.44GiB
-    Device allocated:                    432.02GiB
-    Device unallocated:                   44.42GiB
-    Device missing:                      476.44GiB
-    Used:                                352.13GiB
-    Free (estimated):                    122.57GiB      (min: 122.57GiB)
-    Data ratio:                               1.00
-    Metadata ratio:                           1.00
-    Global reserve:                        0.43GiB      (used: 0.00GiB)
-
-Data,single: Size:429.01GiB, Used:350.85GiB (81.78%)
-
-Metadata,single: Size:3.01GiB, Used:1.28GiB (42.56%)
-
-System,single: Size:0.00GiB, Used:0.00GiB (1.95%)
-
-
-Overall:
-    Device size:                        3726.02GiB
-    Device allocated:                    592.01GiB
-    Device unallocated:                 3134.02GiB
-    Device missing:                     3726.02GiB
-    Used:                                591.27GiB
-    Free (estimated):                   1567.03GiB      (min: 1567.03GiB)
-    Data ratio:                               1.00
-    Metadata ratio:                           1.00
-    Global reserve:                        0.50GiB      (used: 0.00GiB)
-
-Data,single: Size:590.00GiB, Used:589.95GiB (99.99%)
-
-Metadata,single: Size:2.00GiB, Used:1.32GiB (66.16%)
-
-System,single: Size:0.01GiB, Used:0.00GiB (1.03%)
-
-"""
-        ]
-    )
-    def test_df_and_btrfs(self, _):
-        """Test computations around `df` and `btrfs` outputs"""
-        self.assertDictEqual(
-            Disk().value,
-            {
-                'used': 989.304296875,
-                'total': 4501.1016015625,
-                'unit': 'GiB'
-            }
-        )
-
-    @patch(
-        'archey.entries.disk.check_output',
-        side_effect=[
-            CalledProcessError(1, 'df', "df: no file systems processed\n"),
-            """\
-Mounted on
-/
-/vol
-""",
-            """\
-/dev/nvme0n1p1, ID: 1
-   Device size:               0.00B
-   Device slack:              0.00B
-   Unallocated:           476.44GiB
-
-""",
-            """\
-/dev/sda1, ID: 1
-   Device size:               0.00B
-   Device slack:              0.00B
-   Unallocated:             3.64TiB
-
-/dev/sdb1, ID: 2
-   Device size:               0.00B
-   Device slack:              0.00B
-   Unallocated:             3.64TiB
-
-""",
-            """\
-Overall:
-    Device size:                         476.44GiB
-    Device allocated:                    432.02GiB
-    Device unallocated:                   44.42GiB
-    Device missing:                      476.44GiB
-    Used:                                352.13GiB
-    Free (estimated):                    122.57GiB      (min: 122.57GiB)
-    Data ratio:                               1.00
-    Metadata ratio:                           1.00
-    Global reserve:                        0.43GiB      (used: 0.00GiB)
-
-Data,single: Size:429.01GiB, Used:350.85GiB (81.78%)
-
-Metadata,single: Size:3.01GiB, Used:1.28GiB (42.56%)
-
-System,single: Size:0.00GiB, Used:0.00GiB (1.95%)
-
-
-Overall:
-    Device size:                        7452.04GiB
-    Device allocated:                   1184.02GiB
-    Device unallocated:                 6268.03GiB
-    Device missing:                     7452.04GiB
-    Used:                               1182.54GiB
-    Free (estimated):                   3134.06GiB      (min: 3134.06GiB)
-    Data ratio:                               2.00
-    Metadata ratio:                           2.00
-    Global reserve:                        0.50GiB      (used: 0.00GiB)
-
-Data,RAID1: Size:590.00GiB, Used:589.95GiB
-
-Metadata,RAID1: Size:2.00GiB, Used:1.32GiB
-
-System,RAID1: Size:0.01GiB, Used:0.00GiB
-
-"""
-        ]
-    )
-    def test_btrfs_only_with_raid_configuration(self, _):
-        """Test computations around `btrfs` outputs with a RAID-1 setup"""
-        self.assertDictEqual(
-            Disk().value,
-            {
-                'used': 943.4,
-                'total': 4202.46,
-                'unit': 'GiB'
-            }
-        )
-
-    @patch(
-        'archey.entries.disk.check_output',
-        side_effect=[
-            CalledProcessError(1, 'df', "df: unrecognized option: l\n"),
-            CalledProcessError(1, 'df', "df: unrecognized option: l\n")
-        ]
-    )
-    def test_df_failing(self, _):
-        """Test df call failing against the BusyBox implementation"""
-        self.assertIsNone(Disk().value)
-
-    @patch(
-        'archey.entries.disk.check_output',
-        side_effect=[
-            CalledProcessError(1, 'df', "df: no file systems processed\n"),
-            CalledProcessError(1, 'df', "df: no file systems processed\n")
-        ]
-    )
-    def test_no_recognised_disks(self, _):
-        """Test df failing to detect any valid file-systems"""
-        self.assertIsNone(Disk().value)
+        for level, blocks_color_tuple in levels.items():
+            with self.subTest(level):
+                self.disk_instance_mock.value = {
+                    'mount_point': {
+                        'device_path': '/dev/my-cool-disk',
+                        'used_blocks': blocks_color_tuple[0],
+                        'total_blocks': 100
+                    }
+                }
+                Disk.output(self.disk_instance_mock, self.output_mock)
+                self.output_mock.append.assert_called_with(
+                    'Disk',
+                    '{color}{used}.0 KiB{clear} / 100.0 KiB'.format(
+                        color=blocks_color_tuple[1],
+                        used=blocks_color_tuple[0],
+                        clear=Colors.CLEAR
+                    )
+                )
 
 
 if __name__ == '__main__':

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -49,7 +49,7 @@ class TestDiskEntry(unittest.TestCase):
             ""
         ))
     )
-    def test_df_output_dict(self, _):
+    def test_disk_df_output_dict(self, _):
         """Test method to get `df` output as a dict by mocking calls to `check_output`."""
         self.assertDictEqual(
             Disk.get_df_output_dict(),
@@ -71,6 +71,30 @@ class TestDiskEntry(unittest.TestCase):
                 }
             }
         )
+
+    def test_disk_blocks_to_human_readable(self):
+        """Test method to convert 1024-byte blocks to a human readable format."""
+        # Each tuple is a number of blocks followed by the expected output.
+        tests = (
+            (1, '1.0 KiB'),
+            (1024, '1.0 MiB'),
+            (2048, '2.0 MiB'),
+            (95604, '93.4 MiB'),
+            (1048576, '1.0 GiB'),
+            (2097152, '2.0 GiB'),
+            (92156042, '87.9 GiB'),
+            (1073742000, '1.0 TiB'),
+            (2147484000, '2.0 TiB'),
+            (458028916298, '426.6 TiB'),
+            (1099512000000, '1.0 PiB'),
+            (2199023000000, '2.0 PiB')  # I think we can safely stop here :)
+        )
+        for test in tests:
+            with self.subTest(test[1]):
+                self.assertEqual(
+                    Disk._blocks_to_human_readable(test[0]),  # pylint: disable=protected-access
+                    test[1]
+                )
 
     def test_disk_output_colors(self):
         """Test `output` disk level coloring."""

--- a/archey/test/test_archey_disk.py
+++ b/archey/test/test_archey_disk.py
@@ -272,20 +272,23 @@ class TestDiskEntry(unittest.TestCase):
             self.disk_instance_mock._configuration['disk']['combine_total'] = False  # pylint: disable=protected-access
             Disk.output(self.disk_instance_mock, self.output_mock)
             self.assertEqual(self.output_mock.append.call_count, 2)
-            self.output_mock.append.assert_has_calls([
-                call(
-                    'Disk',
-                    '{0}10.0 KiB{1} / 10.0 KiB'.format(
-                        Colors.RED_NORMAL, Colors.CLEAR
+            self.output_mock.append.assert_has_calls(
+                [
+                    call(
+                        'Disk',
+                        '{0}10.0 KiB{1} / 10.0 KiB'.format(
+                            Colors.RED_NORMAL, Colors.CLEAR
+                        )
+                    ),
+                    call(
+                        'Disk',
+                        '{0}10.0 KiB{1} / 30.0 KiB'.format(
+                            Colors.GREEN_NORMAL, Colors.CLEAR
+                        )
                     )
-                ),
-                call(
-                    'Disk',
-                    '{0}10.0 KiB{1} / 30.0 KiB'.format(
-                        Colors.GREEN_NORMAL, Colors.CLEAR
-                    )
-                )
-            ])
+                ],
+                any_order=True  # Since Python < 3.6 doesn't have definite `dict` ordering.
+            )
 
 
 if __name__ == '__main__':

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -97,7 +97,7 @@ fpm \
 	--depends 'python3-netifaces' \
 	--python-install-lib usr/lib/python3/dist-packages/ \
 	--deb-priority 'optional' \
-	--deb-field 'Suggests: dnsutils, lm-sensors, pciutils, wmctrl, virt-what, btrfs-progs' \
+	--deb-field 'Suggests: dnsutils, lm-sensors, pciutils, wmctrl, virt-what' \
 	--deb-no-default-config-files \
 	setup.py
 
@@ -152,7 +152,6 @@ done
 # 	--pacman-optional-depends 'pciutils: GPU wouldn'"'"'t be detected without it' \
 # 	--pacman-optional-depends 'wmctrl: WindowManager would be more accurate' \
 # 	--pacman-optional-depends 'virt-what: Model would contain details about the hypervisor' \
-# 	--pacman-optional-depends 'btrfs-progs: Disk would support BTRFS in usage computations' \
 # 	setup.py
 
 


### PR DESCRIPTION
Yet more rewriting code! 😨 

## Reason and / or context
This is a full rework of the `Disk` entry in an effort to implement #55 and fix #62. It may also potentially be faster as it relies on only a single call to `df` for input, and nothing else. 
This also additionally fixes an (unreported) bug, where we don't actually calculate the correct space usage in `Disk` currently... oops!

## How has this been tested ?
It seems to work fine so far... Some tests have been written for the new functionality, some are TBC. (**This section to be completed properly before converting to a full PR 😁**)

@HorlogeSkynet Could you let me know what you think of this approach? I'm up for changing it but basing all of our calculations around a single basic `df` call like this is what I came up with after some thinking on how to approach reworking this entry. TIA!

## Behaviour changes
Since I'm not sure how `df -l` determines local filesystems, I've taken a guess at defining "local" filesystems as all `/dev/xxx` devices, excluding:
Loop devices:-
* /dev(/...)/loop filesystems (Linux)
* /dev(/...)/*vnd filesystems (BSD)
* /dev(/...)/lofi filesystems (Solaris)

Device mappers:- (since their partitions are already included!)
* /dev(/...)/dm filesystems (Linux)

This is highly likely to be a change in behaviour from our existing implementation (and may be erronous)! From what I can tell, this excludes all `/dev/` devices that are not local, while including all local disks only once (since their device-paths are deduplicated). This logic also hinges on all local disks always having an entry in `/dev/` on all Unix-like/POSIX OSes, which *may* possibly not be true.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [X] [**SEE ABOVE**] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] I have updated the _README.md_ file accordingly ;
- [ ] **[TODO: test cases once we have a final behaviour]** ~~I have updated the test cases (which pass) accordingly ;~~
- [ ] **[TODO: Finalise behaviour]** ~~My changes looks good ;~~
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
