### PR TITLE
[GPU] Adds support for multiple GPUs (and fixes their display order)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ Below, some further explanations of each option available :
 		// `false` would make Archey displays only IPv4 WAN addresses.
 		"wan_ip_v6_support": true
 	},
+	"gpu": {
+		// Display all GPUs on one line if true, multiple lines if false.
+		"one_line": false,
+		// The maximum number of GPUs you want to display.
+		// `false` --> Unlimited.
+		"max_count": 4
+	},
 	"limits": {
 		// Some threshold values you can adjust affecting disk/ram warning/danger color (percent).
 		"ram": {

--- a/README.md
+++ b/README.md
@@ -200,11 +200,11 @@ Below, some further explanations of each option available :
 		"wan_ip_v6_support": true
 	},
 	"gpu": {
-		// Display all GPUs on one line if true, multiple lines if false.
-		"one_line": false,
+		// Display GPUs on multiple lines if set to `false`.
+		"one_line": true,
 		// The maximum number of GPUs you want to display.
 		// `false` --> Unlimited.
-		"max_count": 4
+		"max_count": 2
 	},
 	"limits": {
 		// Some threshold values you can adjust affecting disk/ram warning/danger color (percent).

--- a/archey/config.json
+++ b/archey/config.json
@@ -30,6 +30,10 @@
 		"not_detected": "Not detected",
 		"virtual_environment": "Virtual Environment"
 	},
+	"gpu": {
+		"one_line": false,
+		"max_count": false
+	},
 	"ip_settings": {
 		"lan_ip_max_count": 2,
 		"lan_ip_v6_support": true,

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -24,6 +24,7 @@ class Configuration(metaclass=Singleton):
                 'not_detected': 'Not detected',
                 'virtual_environment': 'Virtual Environment'
             },
+            'gpu': {},
             'ip_settings': {
                 'lan_ip_max_count': 2,
                 'lan_ip_v6_support': True,

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -24,7 +24,10 @@ class Configuration(metaclass=Singleton):
                 'not_detected': 'Not detected',
                 'virtual_environment': 'Virtual Environment'
             },
-            'gpu': {},
+            'gpu': {
+                'one_line': True,
+                'max_count': 2
+            },
             'ip_settings': {
                 'lan_ip_max_count': 2,
                 'lan_ip_v6_support': True,

--- a/archey/entries/gpu.py
+++ b/archey/entries/gpu.py
@@ -6,22 +6,21 @@ from archey.entry import Entry
 
 
 class GPU(Entry):
-    """Relies on `lspci` to retrieve graphics device(s) information"""
+    """Relies on `lspci` to retrieve graphical device(s) information"""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # This list will contain GPU devices detected on this system.
         self.gpu_devices = []
 
-        # Let's try `lspci` here.
+        # Let's try to run `lspci` and parse here.
         self._run_lspci()
 
         self.value = ', '.join(self.gpu_devices) or \
             self._configuration.get('default_strings')['not_detected']
 
     def _run_lspci(self):
-        """Based on `lspci` output, retrieve a list of GPU devices"""
-        # Let's ask `lspci` for a list of current PCI devices on this system.
+        """Based on `lspci` output, retrieve a list of video controllers names"""
         try:
             lspci_output = check_output(
                 ['lspci'],
@@ -30,8 +29,10 @@ class GPU(Entry):
         except (FileNotFoundError, CalledProcessError):
             return
 
-        # Prepares a list of video-only controllers (weighted by the below keys).
+        # We'll be looking for specific video controllers (in the below keys order).
         for video_key in ('3D', 'VGA', 'Display'):
             for pci_device in lspci_output:
+                # If a controller type match...
                 if video_key in pci_device:
+                    # ... adds its name to our final list.
                     self.gpu_devices.append(pci_device.partition(': ')[2])

--- a/archey/entry.py
+++ b/archey/entry.py
@@ -19,4 +19,4 @@ class Entry(AbstractBaseClass):
 
     def output(self, output):
         """Output the results to output. Can be overridden by subclasses."""
-        output.append(self.name, self.value)
+        output.append((self.name, self.value))

--- a/archey/output.py
+++ b/archey/output.py
@@ -27,6 +27,9 @@ class Output:
     It also handles the logo choice based on some system detections.
     """
     def __init__(self):
+        # Fetch a reference to `Configuration` singleton in this class.
+        self._configuration = Configuration()
+
         # First we check whether the Kernel has been compiled as a WSL.
         if 'microsoft' in check_output(['uname', '-r'], universal_newlines=True).lower():
             self._distribution = Distributions.WINDOWS
@@ -51,7 +54,7 @@ class Output:
         # If `os-release`'s `ANSI_COLOR` option is set, honor it.
         # See <https://www.freedesktop.org/software/systemd/man/os-release.html#ANSI_COLOR=>.
         ansi_color = distro.os_release_attr('ansi_color')
-        if ansi_color and Configuration().get('colors_palette')['honor_ansi_color']:
+        if ansi_color and self._configuration.get('colors_palette')['honor_ansi_color']:
             # Replace each Archey integrated colors by `ANSI_COLOR`.
             self._colors_palette = len(self._colors_palette) * \
                 [Colors.escape_code_from_attrs(ansi_color)]
@@ -65,14 +68,14 @@ class Output:
         """Append an entry to the list of entries to output"""
         self._entries.append(module)
 
-    def append(self, key, value):
+    def append(self, data):
         """Append a pre-formatted entry to the final output content"""
         self._results.append(
             '{color}{key}:{clear} {value}'.format(
                 color=self._colors_palette[0],
-                key=key,
+                key=data[0],
                 clear=Colors.CLEAR,
-                value=value
+                value=(data[1] or self._configuration('default_strings')['not_detected'])
             )
         )
 

--- a/archey/test/test_archey_gpu.py
+++ b/archey/test/test_archey_gpu.py
@@ -31,7 +31,43 @@ XX:YY.H Audio device: DDDDDDDDDDDDDDDD
     @patch(
         'archey.configuration.Configuration.get',
         side_effect=[
-            {'max_count': None}
+            {'max_count': 2},
+            {'one_line': True}
+        ]
+    )
+    @patch(
+        'archey.entries.gpu.check_output',
+        return_value="""\
+XX:YY.H IDE interface: IIIIIIIIIIIIIIII
+XX:YY.H SMBus: BBBBBBBBBBBBBBBB
+XX:YY.H VGA compatible controller: GPU-MODEL-NAME
+XX:YY.H Display controller: ANOTHER-MATCHING-VIDEO-CONTROLLER
+XX:YY.H Audio device: DDDDDDDDDDDDDDDD
+XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
+""")
+    def test_multi_matches_capped_one_line(self, _, __):
+        """
+        Test detection when there are multiple graphical device candidates.
+        Check that `max_count` and `one_line` are honored too, including on `output` overriding.
+        """
+        gpu_entry = GPU()
+        output = []
+        gpu_entry.output(output)
+
+        self.assertListEqual(
+            gpu_entry.gpu_devices,
+            ['3D GPU-MODEL-NAME TAKES ADVANTAGE', 'GPU-MODEL-NAME']
+        )
+        self.assertEqual(
+            output[0][1],
+            '3D GPU-MODEL-NAME TAKES ADVANTAGE, GPU-MODEL-NAME'
+        )
+
+    @patch(
+        'archey.configuration.Configuration.get',
+        side_effect=[
+            {'max_count': False},
+            {'one_line': False}
         ]
     )
     @patch(
@@ -43,17 +79,33 @@ XX:YY.H Display controller: ANOTHER-MATCHING-VIDEO-CONTROLLER
 XX:YY.H Audio device: DDDDDDDDDDDDDDDD
 XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
 """)
-    def test_multi_matches(self, _, __):
-        """Test detection when there are multiple graphical candidates"""
+    def test_multi_matches_uncapped_multiple_lines(self, _, __):
+        """
+        Test detection when there are multiple graphical device candidates.
+        Check that `max_count` and `one_line` are honored too, including on `output` overriding.
+        """
+        gpu_entry = GPU()
+        output = []
+        gpu_entry.output(output)
+
         self.assertListEqual(
-            GPU().gpu_devices,
+            gpu_entry.gpu_devices,
             ['3D GPU-MODEL-NAME TAKES ADVANTAGE', 'ANOTHER-MATCHING-VIDEO-CONTROLLER']
+        )
+        self.assertEqual(
+            output[0][1],
+            '3D GPU-MODEL-NAME TAKES ADVANTAGE'
+        )
+        self.assertEqual(
+            output[1][1],
+            'ANOTHER-MATCHING-VIDEO-CONTROLLER'
         )
 
     @patch(
         'archey.configuration.Configuration.get',
         side_effect=[
-            {'max_count': None}
+            {'max_count': None},
+            {'one_line': True}
         ]
     )
     @patch(
@@ -65,21 +117,32 @@ XX:YY.H Audio device: DDDDDDDDDDDDDDDD
 """)
     def test_no_match(self, _, __):
         """Test (non-)detection when there is not any graphical candidate"""
-        self.assertListEqual(GPU().gpu_devices, [])
+        gpu_entry = GPU()
+        output = []
+        gpu_entry.output(output)
+
+        self.assertFalse(gpu_entry.gpu_devices)
+        self.assertFalse(output[0][1])
 
     @patch(
         'archey.configuration.Configuration.get',
         side_effect=[
-            {'max_count': None}
+            {'max_count': None},
+            {'one_line': False}
         ]
     )
     @patch(
         'archey.entries.gpu.check_output',
         side_effect=CalledProcessError(1, 'lspci')
     )
-    def test_lspsci_crash(self, _, __):
+    def test_lspci_crash(self, _, __):
         """Test (non-)detection due to a crashing `lspci` program"""
-        self.assertListEqual(GPU().gpu_devices, [])
+        gpu_entry = GPU()
+        output = []
+        gpu_entry.output(output)
+
+        self.assertFalse(gpu_entry.gpu_devices)
+        self.assertFalse(output[0][1])
 
 
 if __name__ == '__main__':

--- a/archey/test/test_archey_gpu.py
+++ b/archey/test/test_archey_gpu.py
@@ -10,7 +10,6 @@ from archey.entries.gpu import GPU
 
 class TestGPUEntry(unittest.TestCase):
     """Here, we mock the `check_output` call to `lspci` to test the logic"""
-
     @patch(
         'archey.entries.gpu.check_output',
         return_value="""\
@@ -20,7 +19,7 @@ XX:YY.H VGA compatible controller: GPU-MODEL-NAME
 XX:YY.H Audio device: DDDDDDDDDDDDDDDD
 """)
     def test_match_vga(self, _):
-        """Simple "VGA" device type matching"""
+        """Simple 'VGA' device type matching"""
         self.assertEqual(GPU().value, 'GPU-MODEL-NAME')
 
     @patch(
@@ -28,7 +27,7 @@ XX:YY.H Audio device: DDDDDDDDDDDDDDDD
         return_value="""\
 XX:YY.H IDE interface: IIIIIIIIIIIIIIII
 XX:YY.H SMBus: BBBBBBBBBBBBBBBB
-XX:YY.H Display controller: ANOTHER MATCHING VIDEO CONTROLLER
+XX:YY.H Display controller: ANOTHER-MATCHING-VIDEO-CONTROLLER
 XX:YY.H Audio device: DDDDDDDDDDDDDDDD
 XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
 """)
@@ -36,7 +35,7 @@ XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
         """Test detection when there are multiple graphical candidates"""
         self.assertEqual(
             GPU().value,
-            '3D GPU-MODEL-NAME TAKES ADVANTAGE, ANOTHER MATCHING VIDEO CONTROLLER'
+            '3D GPU-MODEL-NAME TAKES ADVANTAGE, ANOTHER-MATCHING-VIDEO-CONTROLLER'
         )
 
     @patch(

--- a/archey/test/test_archey_output.py
+++ b/archey/test/test_archey_output.py
@@ -196,7 +196,7 @@ class TestOutputUtil(unittest.TestCase):
     def test_append_regular(self, _, __, ___):
         """Test the `append` method, for new entries"""
         output = Output()
-        output.append('KEY', 'VALUE')
+        output.append(('KEY', 'VALUE'))
 
         self.assertListEqual(
             output._results,  # pylint: disable=protected-access


### PR DESCRIPTION
Closes #61.

## Description
<!--- Describe your changes in detail -->
GPUs were not following `3D` > `VGA` > `Display` order (poor implementation), and only one was displayed.
This should be fixed now.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
See #61.

## How has this been tested ?
<!--- Include details of your testing environment here -->
Test cases.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
