### PR TITLE
[TERMINAL] Improves terminal detection based on environment variables

### DIFF
--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -10,7 +10,7 @@ from archey.entry import Entry
 #   which do not propagate `TERM_PROGRAM`.
 # When a key is found in environment, a normalization is performed with its corresponding value.
 TERM_DICT = {
-    'ALACRITTY_LOG_ENV': 'Alacritty',
+    'ALACRITTY_LOG': 'Alacritty',
     'GNOME_TERMINAL_SCREEN': 'GNOME Terminal',
     'GUAKE_TAB_UUID': 'Guake',
     'KONSOLE_VERSION': 'Konsole',

--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -13,6 +13,7 @@ TERM_DICT = {
     'ALACRITTY_LOG': 'Alacritty',
     'GNOME_TERMINAL_SCREEN': 'GNOME Terminal',
     'GUAKE_TAB_UUID': 'Guake',
+    'KITTY_WINDOW_ID': 'Kitty',
     'KONSOLE_VERSION': 'Konsole',
     'MLTERM': 'MLTERM',
     'TERMINATOR_UUID': 'Terminator'
@@ -27,8 +28,10 @@ class Terminal(Entry):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        terminal_emulator = self._detect_terminal_emulator() or \
-            self._configuration.get('default_strings')['not_detected']
+        terminal_emulator = (
+            self._detect_terminal_emulator()
+            or self._configuration.get('default_strings')['not_detected']
+        )
         colors_palette = self._get_colors_palette()
 
         self.value = '{0} {1}'.format(terminal_emulator, colors_palette)

--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -6,6 +6,24 @@ from archey.colors import Colors
 from archey.entry import Entry
 
 
+# This dictionary contains environment variables used to detect terminal emulators.
+# Such an identification is _still_ not standardized.
+# See <https://github.com/Maximus5/ConEmu/issues/1837#issuecomment-469199525>.
+TERM_DICT = {
+    # On its way for normalization ?
+    'TERM_PROGRAM': None,
+    # Manual name overriding per-emulator.
+    'ALACRITTY_LOG_ENV': 'Alacritty',
+    'GNOME_TERMINAL_SCREEN': 'GNOME Terminal',
+    'GUAKE_TAB_UUID': 'Guake',
+    'KONSOLE_VERSION': 'Konsole',
+    'MLTERM': 'MLTERM',
+    'TERMINATOR_UUID': 'Terminator',
+    # Regular fallback.
+    'TERM': None
+}
+
+
 class Terminal(Entry):
     """
     Simple terminal detection based on the `TERM` environment variable.
@@ -14,16 +32,19 @@ class Terminal(Entry):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        terminal = os.getenv(
-            'TERM',
+        terminal_emulator = self._detect_terminal_emulator() or \
             self._configuration.get('default_strings')['not_detected']
-        )
+        colors_palette = self._get_colors_palette()
 
+        self.value = '{0} {1}'.format(terminal_emulator, colors_palette)
+
+    def _get_colors_palette(self):
         # On systems with non-Unicode locales, we imitate '\u2588' character
         # ... with '#' to display the terminal colors palette.
         # This is the default option for backward compatibility.
         use_unicode = self._configuration.get('colors_palette')['use_unicode']
-        colors = ' '.join([
+
+        return ' '.join([
             '{normal}{character}{bright}{character}{clear}'.format(
                 normal=Colors((0, i)),
                 bright=Colors((1, i)),
@@ -32,4 +53,13 @@ class Terminal(Entry):
             ) for i in range(37, 30, -1)
         ])
 
-        self.value = '{0} {1}'.format(terminal, colors)
+    @staticmethod
+    def _detect_terminal_emulator():
+        for env_var, override_value in TERM_DICT.items():
+            if env_var in os.environ:
+                if override_value:
+                    return override_value
+
+                return os.getenv(env_var)
+
+        return None

--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -8,9 +8,9 @@ from archey.entry import Entry
 
 
 # We detect a terminal by using the following three constants in the order below:
-# First, we try using the value in the `TERM_PROGRAM` enviroment variable.
-# Then, we use `COLORTERM_DICT` to try matching a value with the `COLORTERM` environment variable.
-# Third, we use `TERM_DICT` to try matching a value with the $TERM environment variable.
+# First, we try using the value in the `TERM_PROGRAM` environment variable.
+# Then, we use `COLORTERM_DICT` to try matching a value with the `COLORTERM` one.
+# Third, we use `TERM_DICT` to try matching a value with the `TERM` one.
 # Finally, we fall back to custom environment variables defined in `ENV_DICT`.
 # If none of the above tests find a value, we use whichever value was defined in `$TERM`.
 
@@ -19,7 +19,7 @@ from archey.entry import Entry
 
 
 # This dictionary contains values for the `COLORTERM` environment variable for terminal emulators
-#   which do not propogate any other usable environment variable.
+#   which do not propagate any other usable environment variable.
 # If `COLORTERM` matches one of these values, a normalization is performed with its corresponding
 #   value (i.e. the respective terminal emulator).
 # If the variable does not match any keys in this dictionary, it is ignored.
@@ -29,18 +29,18 @@ COLORTERM_DICT = {
 }
 
 # This dictionary contains values for the `TERM` environment variable for terminal emulators
-#   which do not propogate any other usable environment variable.
+#   which do not propagate any other usable environment variable.
 # If `TERM` matches one of these values, a normalization is performed with its corresponding
 #   value (i.e. the respective terminal emulator).
 # If the variable does not match any keys in this dictionary, it is ignored,
 #   UNLESS it does not begin with `xterm`, at which point its value is taken as the terminal in use.
-#   This behaviour can be overridden by specifying its exact match here.
+#   This behavior can be overridden by specifying its exact match here.
 TERM_DICT = {
     r'xterm-termite': 'Termite',
 }
 
 # This dictionary contains environment variables used to detect terminal emulators...
-#   which do not propagate a usable `COLORTERM`, `TERM`, or `TERM_PROGRAM`.
+#   which do not propagate any usable `COLORTERM`, `TERM`, or `TERM_PROGRAM`.
 # When a key is found in environment, a normalization is performed with its corresponding value.
 ENV_DICT = {
     'ALACRITTY_LOG': 'Alacritty',
@@ -107,6 +107,7 @@ class Terminal(Entry):
             for env_value_re, normalized_name in TERM_DICT.items():
                 if re.match(env_value_re, env_term):
                     return normalized_name
+
             # If we didn't find any match and `TERM` is set to "something special", honor it.
             if not env_term.startswith('xterm'):
                 return env_term

--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -54,8 +54,14 @@ class Terminal(Entry):
         """Try to detect current terminal emulator based on various environment variables"""
         # At first, try to honor `TERM_PROGRAM` environment variable.
         # See <https://github.com/Maximus5/ConEmu/issues/1837#issuecomment-469199525>.
-        if 'TERM_PROGRAM' in os.environ:
-            return os.getenv('TERM_PROGRAM')
+        env_term_program = os.getenv('TERM_PROGRAM')
+        if env_term_program:
+            return env_term_program
+
+        # Secondly, if `TERM` is set to "something special", honor it.
+        env_term = os.getenv('TERM')
+        if env_term and not env_term.startswith('xterm'):
+            return env_term
 
         # If not, try to find a "known identifier" and perform name normalization...
         for env_var, normalized_name in TERM_DICT.items():
@@ -63,5 +69,5 @@ class Terminal(Entry):
                 return normalized_name
 
         # When nothing of the above matched, falls-back on the regular `TERM` environment variable.
-        # Note : It _might_ be empty too in very specific environments.
-        return os.getenv('TERM')
+        # Note : It _might_ be `None` in very specific environments.
+        return env_term

--- a/archey/test/test_archey_terminal.py
+++ b/archey/test/test_archey_terminal.py
@@ -107,7 +107,7 @@ class TestTerminalEntry(unittest.TestCase):
     )
     def test_terminal_emulator_colorterm_override(self, _):
         """
-        Check we observe terminals using `COLORTERM` even if `TERM` or a known identifier is found.
+        Check we observe terminal using `COLORTERM` even if `TERM` or a "known identifier" is found.
         """
         output = Terminal().value
         self.assertTrue(output.startswith('KMSCON'))

--- a/archey/test/test_archey_terminal.py
+++ b/archey/test/test_archey_terminal.py
@@ -24,9 +24,26 @@ class TestTerminalEntry(unittest.TestCase):
         return_value={'use_unicode': False}
     )
     def test_terminal_emulator_term_program(self, _):
-        """Check that `TERM_PROGRAM` is honored even when `TERM` is defined"""
+        """Check that `TERM_PROGRAM` is honored even if `TERM` is defined"""
         output = Terminal().value
         self.assertTrue(output.startswith('A-COOL-TERMINAL-EMULATOR'))
+
+    @patch.dict(
+        'archey.entries.terminal.os.environ',
+        {
+            'TERM': 'OH-A-SPECIAL-CASE',
+            'TERMINATOR_UUID': 'urn:uuid:xxxxxxxx-yyyy-zzzz-tttt-uuuuuuuuuuuu'  # Ignored.
+        },
+        clear=True
+    )
+    @patch(
+        'archey.configuration.Configuration.get',
+        return_value={'use_unicode': False}
+    )
+    def test_terminal_emulator_special_term(self, _):
+        """Check that `TERM` is honored even if a "known identifier" could be found"""
+        output = Terminal().value
+        self.assertTrue(output.startswith('OH-A-SPECIAL-CASE'))
 
     @patch.dict(
         'archey.entries.terminal.os.environ',


### PR DESCRIPTION
Closes #65.

## Description
<!--- Describe your changes in detail -->
Simple patch implementing an automatic and manual detection of terminal emulators.
One may easily add support for another emulator by adding `X_EMULATOR_SPECIFIC_ENV_VAR` --> `Terminal Emulator Name` association to the current list.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
See #65 for rationale.

## How has this been tested ?
<!--- Include details of your testing environment here -->
Test cases + my system.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
