### PR TITLE
[FEATURE] Makes entries being loaded in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Below, some further explanations of each option available :
 <!-- We use JavaScript syntax coloration below because JSON does not allow the usage of comments in it -->
 ```javascript
 {
+	// Set to `false` to disable multi-threaded loading of entries.
+	"parallel_loading": true,
 	// If set to `false`, configurations defined afterwards won't be loaded.
 	// Developers running Archey from the original project may keep in there the original `config.json` while having their own external configuration set elsewhere.
 	"allow_overriding": true,

--- a/archey/__main__.py
+++ b/archey/__main__.py
@@ -113,9 +113,9 @@ def main():
             # We use threads (and not processes) since most work done by our entries is IO-bound.
             # `max_workers` is manually computed to mimic Python 3.8+ behaviour, but for our needs.
             #   See <https://github.com/python/cpython/pull/13618>.
-            executor = cm_stack.enter_context(
-                ThreadPoolExecutor(max_workers=min(len(enabled_entries), (os.cpu_count() or 1) + 4))
-            )
+            executor = cm_stack.enter_context(ThreadPoolExecutor(
+                max_workers=min(len(enabled_entries) or 1, (os.cpu_count() or 1) + 4)
+            ))
             mapper = executor.map
 
         for entry_instance in mapper(_entry_instantiator, enabled_entries):

--- a/archey/__main__.py
+++ b/archey/__main__.py
@@ -111,10 +111,10 @@ def main():
         else:
             # Instantiate a threads pool to load our enabled entries in parallel.
             # We use threads (and not processes) since most work done by our entries is IO-bound.
-            # Note: For Python < 3.5, we manually compute `max_workers`.
-            # See <https://github.com/python/cpython/blob/3.5/Lib/concurrent/futures/thread.py#L94>.
+            # `max_workers` is manually computed to mimic Python 3.8+ behaviour, but for our needs.
+            #   See <https://github.com/python/cpython/pull/13618>.
             executor = cm_stack.enter_context(
-                ThreadPoolExecutor(max_workers=((os.cpu_count() or 1) * 5))
+                ThreadPoolExecutor(max_workers=min(len(enabled_entries), (os.cpu_count() or 1) + 4))
             )
             mapper = executor.map
 

--- a/archey/config.json
+++ b/archey/config.json
@@ -1,4 +1,5 @@
 {
+	"parallel_loading": true,
 	"allow_overriding": true,
 	"suppress_warnings": false,
 	"entries": {

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -15,6 +15,7 @@ class Configuration(metaclass=Singleton):
     """
     def __init__(self):
         self._config = {
+            'parallel_loading': True,
             'colors_palette': {
                 'use_unicode': True,
                 'honor_ansi_color': True


### PR DESCRIPTION
This patch is mainly inspired from the work of @ingrinder (see `2bbc2dae`).
You may notice an execution up to twice as fast.

This new behavior could be disabled with the new `parallel_loading` configuration option.

See #68.

## How has this been tested ?
<!--- Include details of your testing environment here -->
Locally & test cases.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change [?] (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- ~~[ ] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;~~
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
