### PR TITLE
[FEATURE] [BREAKING] Change configuration layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,106 +180,139 @@ You can place a [`config.json`](archey/config.json) file in these locations :
 
 **If an option is defined in multiple places, it will be overridden according to the order above (local preferences > user preferences > system preferences).**
 
+Alternatively, you may specify your own configuration file with the `-c` command-line option.
+
 The [example file](archey/config.json) provided in this repository lists exhaustively the parameters you can set.  
-Below stand further descriptions for each available option :
+Below stand further descriptions for each available (default) option :
 
 <!-- We use JavaScript syntax coloration below because JSON does not allow the usage of comments in it -->
 ```javascript
 {
 	// If set to `false`, configurations defined afterwards won't be loaded.
-	// Developers running Archey from the original project may keep in there the original `config.json` while having their own external configuration set elsewhere.
+	// Developers running Archey from the original project may keep in there the original `config.json`,
+	//   while having their own external configuration set elsewhere.
 	"allow_overriding": true,
 	// Set to `false` to disable multi-threaded loading of entries.
 	"parallel_loading": true,
 	// If set to `true`, any execution warning or error would be hidden.
-	// It may not apply to configuration parsing warnings.
+	// Configuration parsing warnings **would** still be shown.
 	"suppress_warnings": false,
-	"entries": {
-		// Set to `false` each entry you want to mask.
-	},
-	"colors_palette": {
-		// Leave this option set to `true` to display a beautiful colors palette.
-		// Set it to `false` to allow compatibility with non-Unicode locales.
-		"use_unicode": true,
-		// Set this option to `false` to force Archey to use its own colors palettes.
-		// `true` by default to honor `os-release`'s `ANSI_COLOR` option.
-		"honor_ansi_color": true
-	},
-	"disk": {
-		// Which filesystems to show:
-		// `["local"]` shows only local filesystems.
-		// You can alternatively list specific filesystems as:
-		//  * A list of device paths - e.g. `["/dev/sda1", "/dev/nvme0n1p1"]`
-		//  * A list of mount points - e.g. `["/", "/mnt"]`
-		//  * A combination of the above - e.g. `["/", "/dev/sda2"]`
-		"show_filesystems": ["local"],
-		// Set to `false` to write each filesystem on its own line.
-		"combine_total": true,
-		// Defines which labels to use for each disk (only works if `combine_total` is false!)
-		// The options available are:
-		//  * `"mount_points"`: Shows the mount point of the filesystem.
-		//      e.g. `Disk (/): 10.0 GiB/100.0 GiB`
-		//           `Disk (/mnt): 15.0 GiB / 200.0 GiB`
-		//  * `"device_paths"`: Shows the device path of the filesystem.
-		//      e.g. `Disk (/dev/sda1): 10.0 GiB / 100.0 GiB`
-		//           `Disk (/dev/mmcblk0p1): 15.0 GiB / 200.0 GiB`
-		//  * `false` or `null` (no quote marks!): Don't show any device labels.
-		//      e.g. `Disk: 10.0 GiB / 100.0 GiB`
-		//           `Disk: 15.0 GiB / 200.0 GiB`
-		"disk_labels": null,
-		// Set to `true` to hide the "Disk" entry name from the output.
-		// i.e. null  --> `Disk (/):`
-		//      false --> `Disk (/):`
-		//      true  --> `(/):`
-		"hide_entry_name": null
-	},
-	"default_strings": {
-		// Use this section to override default strings.
-	},
-	"ip_settings": {
-		// The maximum number of local addresses you want to display.
-		// `false` --> Unlimited.
-		"lan_ip_max_count": 2,
-		// `false` would make Archey display IPv4 LAN addresses only.
-		"lan_ip_v6_support": true,
-		// `false` would make Archey display IPv4 WAN addresses only.
-		"wan_ip_v6_support": true
-	},
-	"gpu": {
-		// Display GPUs on multiple lines if set to `false`.
-		"one_line": true,
-		// The maximum number of GPUs you want to display.
-		// `false` --> Unlimited.
-		"max_count": 2
-	},
-	"limits": {
-		// Some threshold values you can adjust affecting disk/ram warning/danger color (percent).
-		"ram": {
-			"warning": 33.3,
-			"danger": 66.7
+	// Set this option to `false` to force Archey to use its own colors palettes.
+	// `true` by default to honor os-release(5) `ANSI_COLOR` option.
+	"honor_ansi_color": true,
+	// Entries list.
+	// Add a `disabled` option set to `true` to temporary hide one.
+	// You may change entry displayed name by adding a `name` option.
+	// You may re-order the entries list as you wish.
+	"entries": [
+		{ "type": "User" },
+		{ "type": "Hostname" },
+		{ "type": "Model" },
+		{ "type": "Distro" },
+		{ "type": "Kernel" },
+		{ "type": "Uptime" },
+		{ "type": "Processes" },
+		{ "type": "WindowManager" },
+		{ "type": "DesktopEnvironment" },
+		{ "type": "Shell" },
+		{
+			"type": "Terminal",
+			// Leave this option set to `true` to display a beautiful colors palette.
+			// Set it to `false` to allow compatibility with non-Unicode locales.
+			"use_unicode": true
 		},
-		"disk": {
-			"warning": 50,
-			"danger": 75
+		{ "type": "Packages" },
+		{
+			"type": "Temperature",
+			// The character to display between the temperature value and the unit (as '°' in 53.2°C).
+			"char_before_unit": " ",
+			"sensors_chipsets": [
+				// White-list of chipset identifiers (strings) passed to LM-SENSORS when computing the average temperature.
+				// Use `sensors -A` to list the available chipsets on your system (e.g. `coretemp-isa-0000`, `acpitz-acpi-0`, ...).
+				// Leaving empty (default) would make Archey process input data from all available chipsets.
+				// Use this option if a sensor happens to return irrelevant values, or if you want to exclude it.
+			],
+			// Display temperature values in Fahrenheit instead of Celsius.
+			"use_fahrenheit": false
+		},
+		{
+			"type": "CPU",
+			//
+			// As explained above, you may rename entries as you wish.
+			//"name": "Processor"
+		},
+		{
+			"type": "GPU",
+			// Set to `false` to display GPUs on multiple lines.
+			"one_line": true,
+			// The maximum number of GPUs you want to display.
+			// `false` --> Unlimited.
+			"max_count": 2
+		},
+		{
+			"type": "RAM",
+			// Some threshold values you can adjust affecting warning/danger colors.
+			"warning_use_percent": 33.3,
+			"danger_use_percent": 66.7
+		},
+		{
+			"type": "LAN_IP",
+			// The maximum number of local addresses you want to display.
+			// `false` --> Unlimited.
+			"max_count": 2,
+			// Set to `false` to only display IPv4 LAN addresses.
+			"ipv6_support": true
+		},
+		{
+			"type": "Disk",
+			// Which filesystems to show:
+			// `["local"]` shows only local filesystems.
+			// You can alternatively list specific filesystems as:
+			//  * A list of device paths - e.g. `["/dev/sda1", "/dev/nvme0n1p1"]`
+			//  * A list of mount points - e.g. `["/", "/mnt"]`
+			//  * A combination of the above - e.g. `["/", "/dev/sda2"]`
+			"show_filesystems": ["local"],
+			// Set to `false` to write each filesystem on its own line.
+			"combine_total": true,
+			// Defines which labels to use for each disk (only works if `combine_total` is false!)
+			// The options available are:
+			//  * `"mount_points"`: Shows the mount point of the filesystem.
+			//      e.g. `Disk (/): 10.0 GiB/100.0 GiB`
+			//           `Disk (/mnt): 15.0 GiB / 200.0 GiB`
+			//  * `"device_paths"`: Shows the device path of the filesystem.
+			//      e.g. `Disk (/dev/sda1): 10.0 GiB / 100.0 GiB`
+			//           `Disk (/dev/mmcblk0p1): 15.0 GiB / 200.0 GiB`
+			//  * `false` or `null` (no quote marks!): Don't show any device labels.
+			//      e.g. `Disk: 10.0 GiB / 100.0 GiB`
+			//           `Disk: 15.0 GiB / 200.0 GiB`
+			"disk_labels": null,
+			// Set to `true` to hide the "Disk" entry name from the output.
+			// i.e. null  --> `Disk (/):`
+			//      false --> `Disk (/):`
+			//      true  --> `(/):`
+			"hide_entry_name": null
+			// Some threshold values you can adjust affecting warning/danger colors.
+			"warning_use_percent": 50,
+			"danger_use_percent": 75,
+		},
+		{
+			"type": "WAN_IP",
+			// Set to `false` to only display IPv4 WAN addresses.
+			"ipv6_support": true,
+			// Some timeouts you can adjust as default ones might be undersized for your connectivity (seconds).
+			"ipv4_timeout_secs": 1,
+			"ipv6_timeout_secs": 1,
+			//
+			// As explained above, you may temporary hide entries as you wish.
+			// See below example to hide your public IP addresses before posting your configuration on Internet.
+			//"disabled": true
 		}
-	},
-	"temperature": {
-		// The character to display between the temperature value and the unit (as '°' in 53.2°C).
-		// Set to ' ' (space) by default for backward compatibility with non-Unicode locales.
-		"char_before_unit": " ",
-		"sensors_chipsets": [
-			// White-list of chipset identifiers (strings) passed to LM-SENSORS when computing the average temperature.
-			// Uses `sensors -A` to list the available chipsets on your system (e.g. `coretemp-isa-0000`, `acpitz-acpi-0`, ...).
-			// Leaving empty (default) would make Archey process input data from each existing chipset.
-			// Use this option if a sensor happens to return irrelevant values, or if you want to exclude it.
-		],
-		// Display temperature values in Fahrenheit instead of Celsius.
-		"use_fahrenheit": false
-	},
-	"timeout": {
-		// Some values you can adjust if the default ones look undersized for your system (seconds).
+	],
+	"default_strings": {
+		// Use this section to override default strings (internationalization).
 	}
 }
+
 ```
 
 ## Test cases

--- a/archey/config.json
+++ b/archey/config.json
@@ -2,6 +2,7 @@
 	"allow_overriding": true,
 	"parallel_loading": true,
 	"suppress_warnings": false,
+	"honor_ansi_color": true,
 	"entries": [
 		{ "type": "User" },
 		{ "type": "Hostname" },
@@ -9,65 +10,53 @@
 		{ "type": "Distro" },
 		{ "type": "Kernel" },
 		{ "type": "Uptime" },
+		{ "type": "Processes" },
 		{ "type": "WindowManager" },
 		{ "type": "DesktopEnvironment" },
 		{ "type": "Shell" },
-		{ "type": "Terminal" },
+		{
+			"type": "Terminal",
+			"use_unicode": true
+		},
 		{ "type": "Packages" },
 		{
 			"type": "Temperature",
-			"options": {
-				"char_before_unit": " ",
-				"sensors_chipsets": [],
-				"use_fahrenheit": false
-			}
+			"char_before_unit": " ",
+			"sensors_chipsets": [],
+			"use_fahrenheit": false
 		},
 		{ "type": "CPU" },
 		{
 			"type": "GPU",
-			"options": {
-				"one_line": true,
-				"max_count": 2
-			}
+			"one_line": true,
+			"max_count": 2
 		},
 		{
 			"type": "RAM",
-			"options": {
-				"warning": 33.3,
-				"danger": 66.7
-			}
+			"warning_use_percent": 33.3,
+			"danger_use_percent": 66.7
+		},
+		{
+			"type": "LAN_IP",
+			"max_count": 2,
+			"ipv6_support": true
 		},
 		{
 			"type": "Disk",
-			"options": {
-				"show_filesystems": ["local"],
-				"combine_total": true,
-				"disk_labels": null,
-				"hide_entry_name": null,
-				"warning_use_percent": 50,
-				"danger_use_percent": 75
-			}
+			"show_filesystems": ["local"],
+			"combine_total": true,
+			"disk_labels": null,
+			"hide_entry_name": null,
+			"warning_use_percent": 50,
+			"danger_use_percent": 75
 		},
 		{
-			"type": "LanIP",
-			"options": {
-				"max_count": 2,
-				"ipv6_support": true
-			}
-		},
-		{
-			"type": "WanIP",
-			"options": {
-				"ipv6_support": true,
-				"ipv4_timeout_secs": 1,
-				"ipv6_timeout_secs": 1
-			}
+			"type": "WAN_IP",
+			"ipv6_support": true,
+			"ipv4_timeout_secs": 1,
+			"ipv6_timeout_secs": 1
 		}
 	],
-	"colors_palette": {
-		"use_unicode": true,
-		"honor_ansi_color": true
-	},
 	"default_strings": {
 		"no_address": "No Address",
 		"not_detected": "Not detected",

--- a/archey/config.json
+++ b/archey/config.json
@@ -2,68 +2,75 @@
 	"allow_overriding": true,
 	"parallel_loading": true,
 	"suppress_warnings": false,
-	"entries": {
-		"User": true,
-		"Hostname": true,
-		"Model": true,
-		"Distro": true,
-		"Kernel": true,
-		"Uptime": true,
-		"Processes": true,
-		"WindowManager": true,
-		"DesktopEnvironment": true,
-		"Shell": true,
-		"Terminal": true,
-		"Packages": true,
-		"Temperature": true,
-		"CPU": true,
-		"GPU": true,
-		"RAM": true,
-		"Disk": true,
-		"LAN_IP": true,
-		"WAN_IP": true
-	},
+	"entries": [
+		{ "type": "User" },
+		{ "type": "Hostname" },
+		{ "type": "Model" },
+		{ "type": "Distro" },
+		{ "type": "Kernel" },
+		{ "type": "Uptime" },
+		{ "type": "WindowManager" },
+		{ "type": "DesktopEnvironment" },
+		{ "type": "Shell" },
+		{ "type": "Terminal" },
+		{ "type": "Packages" },
+		{
+			"type": "Temperature",
+			"options": {
+				"char_before_unit": " ",
+				"sensors_chipsets": [],
+				"use_fahrenheit": false
+			}
+		},
+		{ "type": "CPU" },
+		{
+			"type": "GPU",
+			"options": {
+				"one_line": true,
+				"max_count": 2
+			}
+		},
+		{
+			"type": "RAM",
+			"options": {
+				"warning": 33.3,
+				"danger": 66.7
+			}
+		},
+		{
+			"type": "Disk",
+			"options": {
+				"show_filesystems": ["local"],
+				"combine_total": true,
+				"disk_labels": null,
+				"hide_entry_name": null,
+				"warning_use_percent": 50,
+				"danger_use_percent": 75
+			}
+		},
+		{
+			"type": "LanIP",
+			"options": {
+				"max_count": 2,
+				"ipv6_support": true
+			}
+		},
+		{
+			"type": "WanIP",
+			"options": {
+				"ipv6_support": true,
+				"ipv4_timeout_secs": 1,
+				"ipv6_timeout_secs": 1
+			}
+		}
+	],
 	"colors_palette": {
 		"use_unicode": true,
 		"honor_ansi_color": true
-	},
-	"disk": {
-		"show_filesystems": ["local"],
-		"combine_total": true,
-		"disk_labels": null,
-		"hide_entry_name": null
 	},
 	"default_strings": {
 		"no_address": "No Address",
 		"not_detected": "Not detected",
 		"virtual_environment": "Virtual Environment"
-	},
-	"gpu": {
-		"one_line": true,
-		"max_count": 2
-	},
-	"ip_settings": {
-		"lan_ip_max_count": 2,
-		"lan_ip_v6_support": true,
-		"wan_ip_v6_support": true
-	},
-	"limits": {
-		"ram": {
-			"warning": 33.3,
-			"danger": 66.7
-		},
-		"disk": {
-			"warning": 50,
-			"danger": 75
-		}
-	},
-	"temperature": {
-		"char_before_unit": " ",
-		"sensors_chipsets": [],
-		"use_fahrenheit": false
-	},
-	"timeout": {
-		"ipv4_detection": 1,
-		"ipv6_detection": 1
 	}
 }

--- a/archey/constants.py
+++ b/archey/constants.py
@@ -75,10 +75,7 @@ DEFAULT_CONFIG = {
     'allow_overriding': True,
     'parallel_loading': True,
     'suppress_warnings': False,
-    'colors_palette': {
-        'use_unicode': True,
-        'honor_ansi_color': True
-    },
+    'honor_ansi_color': True,
     'default_strings': {
         'no_address': 'No Address',
         'not_detected': 'Not detected',

--- a/archey/constants.py
+++ b/archey/constants.py
@@ -79,43 +79,9 @@ DEFAULT_CONFIG = {
         'use_unicode': True,
         'honor_ansi_color': True
     },
-    'disk': {
-        'show_filesystems': ['local'],
-        'combine_total': True,
-        'disk_labels': None,
-        'hide_entry_name': None
-    },
     'default_strings': {
         'no_address': 'No Address',
         'not_detected': 'Not detected',
         'virtual_environment': 'Virtual Environment'
-    },
-    'gpu': {
-        'one_line': True,
-        'max_count': 2
-    },
-    'ip_settings': {
-        'lan_ip_max_count': 2,
-        'lan_ip_v6_support': True,
-        'wan_ip_v6_support': True
-    },
-    'limits': {
-        'ram': {
-            'warning': 33.3,
-            'danger': 66.7
-        },
-        'disk': {
-            'warning': 50,
-            'danger': 75
-        }
-    },
-    'temperature': {
-        'char_before_unit': ' ',
-        'sensors_chipsets': [],
-        'use_fahrenheit': False
-    },
-    'timeout': {
-        'ipv4_detection': 1,
-        'ipv6_detection': 1
     }
 }

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -16,7 +16,7 @@ class Disk(Entry):
         # Populate an output from `df`
         self._disk_dict = self.get_df_output_dict()
 
-        config_filesystems = self._configuration.get('disk')['show_filesystems']
+        config_filesystems = self.entry_options.get('show_filesystems', 'local')
         # See `Disk.get_df_output_dict` for the format we use in `self.value`.
         if config_filesystems == ['local']:
             self.value = self._get_local_filesystems()
@@ -159,11 +159,11 @@ class Disk(Entry):
             return
 
         # DRY configuration object for the output.
-        disk_labels = self._configuration.get('disk')['disk_labels']
-        hide_entry_name = self._configuration.get('disk')['hide_entry_name']
+        disk_labels = self.entry_options.get('disk_labels')
+        hide_entry_name = self.entry_options.get('hide_entry_name')
 
         # Combine all entries into one grand-total if configured to do so.
-        if self._configuration.get('disk')['combine_total']:
+        if self.entry_options.get('combine_total', True):
             name = self.name
 
             # Rewrite our `filesystems` object as one combining all of them.
@@ -191,15 +191,13 @@ class Disk(Entry):
                     name += ' '
                 name += '({disk_label})'
 
-        # Fetch the user-defined limits from the configuration.
-        disk_limits = self._configuration.get('limits')['disk']
-
         # We will only run this loop a single time for combined entries.
         for mount_point, filesystem_data in filesystems.items():
             # Select the corresponding level color based on disk percentage usage.
             level_color = Colors.get_level_color(
                 (filesystem_data['used_blocks'] / filesystem_data['total_blocks']) * 100,
-                disk_limits['warning'], disk_limits['danger']
+                self.entry_options.get('warning_use_percent', 50),
+                self.entry_options.get('danger_use_percent', 75)
             )
 
             # Set the correct disk label

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -14,10 +14,10 @@ class Disk(Entry):
         super().__init__(*args, **kwargs)
 
         # Populate an output from `df`
-        self._disk_dict = self.get_df_output_dict()
+        self._disk_dict = self._get_df_output_dict()
 
-        config_filesystems = self.entry_options.get('show_filesystems', 'local')
-        # See `Disk.get_df_output_dict` for the format we use in `self.value`.
+        config_filesystems = self.options.get('show_filesystems', ['local'])
+        # See `Disk._get_df_output_dict` for the format we use in `self.value`.
         if config_filesystems == ['local']:
             self.value = self._get_local_filesystems()
         else:
@@ -88,7 +88,7 @@ class Disk(Entry):
 
 
     @staticmethod
-    def get_df_output_dict():
+    def _get_df_output_dict():
         """
         Runs `df -P -k` and returns disks in a dict formatted as:
         {
@@ -159,11 +159,11 @@ class Disk(Entry):
             return
 
         # DRY configuration object for the output.
-        disk_labels = self.entry_options.get('disk_labels')
-        hide_entry_name = self.entry_options.get('hide_entry_name')
+        disk_labels = self.options.get('disk_labels')
+        hide_entry_name = self.options.get('hide_entry_name')
 
         # Combine all entries into one grand-total if configured to do so.
-        if self.entry_options.get('combine_total', True):
+        if self.options.get('combine_total', True):
             name = self.name
 
             # Rewrite our `filesystems` object as one combining all of them.
@@ -196,8 +196,8 @@ class Disk(Entry):
             # Select the corresponding level color based on disk percentage usage.
             level_color = Colors.get_level_color(
                 (filesystem_data['used_blocks'] / filesystem_data['total_blocks']) * 100,
-                self.entry_options.get('warning_use_percent', 50),
-                self.entry_options.get('danger_use_percent', 75)
+                self.options.get('warning_use_percent', 50),
+                self.options.get('danger_use_percent', 75)
             )
 
             # Set the correct disk label

--- a/archey/entries/distro.py
+++ b/archey/entries/distro.py
@@ -46,8 +46,7 @@ class Distro(Entry):
         output.append(
             self.name,
             '{0} [{1}]'.format(
-                (self.value['name'] or
-                 self._configuration.get('default_strings')['not_detected']),
+                (self.value['name'] or self._default_strings.get('not_detected')),
                 self.value['arch']
             )
         )

--- a/archey/entries/distro.py
+++ b/archey/entries/distro.py
@@ -46,7 +46,8 @@ class Distro(Entry):
         output.append(
             self.name,
             '{0} [{1}]'.format(
-                (self.value['name'] or self._configuration.get('default_strings')['not_detected']),
+                (self.value['name'] or
+                 self._configuration.get('default_strings')['not_detected']),
                 self.value['arch']
             )
         )

--- a/archey/entries/gpu.py
+++ b/archey/entries/gpu.py
@@ -11,7 +11,7 @@ class GPU(Entry):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        max_count = self._configuration.get('gpu')['max_count']
+        max_count = self.entry_options.get('max_count', 2)
         # Consistency with other entries' configuration: Infinite count if false.
         if max_count is False:
             max_count = None
@@ -42,10 +42,11 @@ class GPU(Entry):
     def output(self, output):
         """Writes GPUs to `output` based on preferences"""
         # Even when no GPU device could be detected, be sure to add an "empty" entry to `output`.
-        if self._configuration.get('gpu')['one_line'] or not self.value:
+        if self.entry_options.get('one_line', True) or not self.value:
             output.append(
                 self.name,
-                ', '.join(self.value) or self._configuration.get('default_strings')['not_detected']
+                (', '.join(self.value) or
+                 self._configuration.get('default_strings')['not_detected'])
             )
         else:
             for gpu_device in self.value:

--- a/archey/entries/gpu.py
+++ b/archey/entries/gpu.py
@@ -11,7 +11,7 @@ class GPU(Entry):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        max_count = self.entry_options.get('max_count', 2)
+        max_count = self.options.get('max_count', 2)
         # Consistency with other entries' configuration: Infinite count if false.
         if max_count is False:
             max_count = None
@@ -42,11 +42,10 @@ class GPU(Entry):
     def output(self, output):
         """Writes GPUs to `output` based on preferences"""
         # Even when no GPU device could be detected, be sure to add an "empty" entry to `output`.
-        if self.entry_options.get('one_line', True) or not self.value:
+        if self.options.get('one_line', True) or not self.value:
             output.append(
                 self.name,
-                (', '.join(self.value) or
-                 self._configuration.get('default_strings')['not_detected'])
+                (', '.join(self.value) or self._default_strings.get('not_detected'))
             )
         else:
             for gpu_device in self.value:

--- a/archey/entries/lan_ip.py
+++ b/archey/entries/lan_ip.py
@@ -10,7 +10,7 @@ except ImportError:
 from archey.entry import Entry
 
 
-class LanIp(Entry):
+class LanIP(Entry):
     """Relies on the `netifaces` module to detect LAN IP addresses"""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -26,7 +26,7 @@ Please either install it or disable `LAN_IP` entry in configuration.\
             return
 
         address_types = [netifaces.AF_INET]
-        if self._configuration.get('ip_settings')['lan_ip_v6_support']:
+        if self.entry_options.get('ipv6_support', True):
             address_types.append(netifaces.AF_INET6)
 
         self.value = []
@@ -49,7 +49,7 @@ Please either install it or disable `LAN_IP` entry in configuration.\
 
                     self.value.append(if_addr['addr'].split('%')[0])
 
-        lan_ip_max_count = self._configuration.get('ip_settings')['lan_ip_max_count']
+        lan_ip_max_count = self.entry_options.get('max_count', 2)
         if lan_ip_max_count is not False:
             self.value = self.value[:lan_ip_max_count]
 

--- a/archey/entries/lan_ip.py
+++ b/archey/entries/lan_ip.py
@@ -26,7 +26,7 @@ Please either install it or disable `LAN_IP` entry in configuration.\
             return
 
         address_types = [netifaces.AF_INET]
-        if self.entry_options.get('ipv6_support', True):
+        if self.options.get('ipv6_support', True):
             address_types.append(netifaces.AF_INET6)
 
         self.value = []
@@ -49,7 +49,7 @@ Please either install it or disable `LAN_IP` entry in configuration.\
 
                     self.value.append(if_addr['addr'].split('%')[0])
 
-        lan_ip_max_count = self.entry_options.get('max_count', 2)
+        lan_ip_max_count = self.options.get('max_count', 2)
         if lan_ip_max_count is not False:
             self.value = self.value[:lan_ip_max_count]
 
@@ -61,8 +61,8 @@ Please either install it or disable `LAN_IP` entry in configuration.\
         if self.value:
             text_output = ', '.join(self.value)
         elif netifaces:
-            text_output = self._configuration.get('default_strings')['no_address']
+            text_output = self._default_strings.get('no_address')
         else:
-            text_output = self._configuration.get('default_strings')['not_detected']
+            text_output = self._default_strings.get('not_detected')
 
         output.append(self.name, text_output)

--- a/archey/entries/model.py
+++ b/archey/entries/model.py
@@ -70,7 +70,7 @@ class Model(Entry):
 
         # If we got there with some info, this _should_ be a virtual environment.
         return '{0} ({1})'.format(
-            product_name or self._configuration.get('default_strings')['virtual_environment'],
+            product_name or self._default_strings.get('virtual_environment'),
             environment
         )
 

--- a/archey/entries/model.py
+++ b/archey/entries/model.py
@@ -16,7 +16,7 @@ class Model(Entry):
         self.value = \
             self._fetch_virtual_env_info() \
             or self._fetch_product_name() \
-            or self._fetch_rasperry_pi_revision() \
+            or self._fetch_raspberry_pi_revision() \
             or self._fetch_android_device_model() \
 
     def _fetch_virtual_env_info(self):
@@ -86,7 +86,7 @@ class Model(Entry):
         return None
 
     @staticmethod
-    def _fetch_rasperry_pi_revision():
+    def _fetch_raspberry_pi_revision():
         """Tries to retrieve 'Hardware' and 'Revision IDs' from `/proc/cpuinfo`"""
         try:
             with open('/proc/cpuinfo') as f_cpu_info:

--- a/archey/entries/ram.py
+++ b/archey/entries/ram.py
@@ -98,13 +98,12 @@ class RAM(Entry):
         used = self.value['used']
         total = self.value['total']
         unit = self.value['unit']
-        # Fetch the user-defined RAM limits from configuration.
-        ram_limits = self._configuration.get('limits')['ram']
 
         # Based on the RAM percentage usage, select the corresponding level color.
         level_color = Colors.get_level_color(
             (used / total) * 100,
-            ram_limits['warning'], ram_limits['danger']
+            self.entry_options.get('warning', 33.3),
+            self.entry_options.get('danger', 66.7)
         )
 
         output.append(

--- a/archey/entries/ram.py
+++ b/archey/entries/ram.py
@@ -102,8 +102,8 @@ class RAM(Entry):
         # Based on the RAM percentage usage, select the corresponding level color.
         level_color = Colors.get_level_color(
             (used / total) * 100,
-            self.entry_options.get('warning', 33.3),
-            self.entry_options.get('danger', 66.7)
+            self.options.get('warning_use_percent', 33.3),
+            self.options.get('danger_use_percent', 66.7)
         )
 
         output.append(

--- a/archey/entries/temperature.py
+++ b/archey/entries/temperature.py
@@ -21,7 +21,7 @@ class Temperature(Entry):
         self._temps = []
 
         # Tries `sensors` at first.
-        self._run_sensors(self._configuration.get('temperature')['sensors_chipsets'])
+        self._run_sensors(self.entry_options.get('sensors_chipsets', []))
 
         # On error (list still empty), checks for system thermal zones files.
         if not self._temps:
@@ -35,8 +35,8 @@ class Temperature(Entry):
             return
 
         # Let's DRY some constants once.
-        use_fahrenheit = self._configuration.get('temperature')['use_fahrenheit']
-        char_before_unit = self._configuration.get('temperature')['char_before_unit']
+        use_fahrenheit = self.entry_options.get('use_fahrenheit')
+        char_before_unit = self.entry_options.get('char_before_unit', ' ')
 
         # Conversion to Fahrenheit if needed.
         if use_fahrenheit:

--- a/archey/entries/temperature.py
+++ b/archey/entries/temperature.py
@@ -21,7 +21,7 @@ class Temperature(Entry):
         self._temps = []
 
         # Tries `sensors` at first.
-        self._run_sensors(self.entry_options.get('sensors_chipsets', []))
+        self._run_sensors(self.options.get('sensors_chipsets', []))
 
         # On error (list still empty), checks for system thermal zones files.
         if not self._temps:
@@ -35,8 +35,8 @@ class Temperature(Entry):
             return
 
         # Let's DRY some constants once.
-        use_fahrenheit = self.entry_options.get('use_fahrenheit')
-        char_before_unit = self.entry_options.get('char_before_unit', ' ')
+        use_fahrenheit = self.options.get('use_fahrenheit')
+        char_before_unit = self.options.get('char_before_unit', ' ')
 
         # Conversion to Fahrenheit if needed.
         if use_fahrenheit:

--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -67,7 +67,8 @@ class Terminal(Entry):
         """Build and return a 8-color palette, with Unicode characters if allowed"""
         # On systems with non-Unicode locales, we imitate '\u2588' character
         # ... with '#' to display the terminal colors palette.
-        use_unicode = self._configuration.get('colors_palette')['use_unicode']
+        # Archey >= v4.8.0, Unicode is enabled by default.
+        use_unicode = self.options.get('use_unicode', True)
 
         return ' '.join([
             '{normal}{character}{bright}{character}{clear}'.format(
@@ -117,7 +118,7 @@ class Terminal(Entry):
 
     def output(self, output):
         """Adds the entry to `output` after pretty-formatting with colors palette"""
-        text_output = (self.value or self._configuration.get('default_strings')['not_detected'])
+        text_output = (self.value or self._default_strings.get('not_detected'))
         if not NO_COLOR:
             text_output += ' ' + self._get_colors_palette()
 

--- a/archey/entries/wan_ip.py
+++ b/archey/entries/wan_ip.py
@@ -8,7 +8,7 @@ from urllib.request import urlopen
 from archey.entry import Entry
 
 
-class WanIp(Entry):
+class WanIP(Entry):
     """Uses different ways to retrieve the public IPv{4,6} addresses"""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -18,7 +18,7 @@ class WanIp(Entry):
         self._retrieve_ipv4_address()
 
         # IPv6 address retrieval (unless the user doesn't want it).
-        if self._configuration.get('ip_settings')['wan_ip_v6_support']:
+        if self.entry_options.get('ipv6_support', True):
             self._retrieve_ipv6_address()
 
         self.value = list(filter(None, self.value))
@@ -30,14 +30,14 @@ class WanIp(Entry):
                     'dig', '+short', '-4', 'A', 'myip.opendns.com',
                     '@resolver1.opendns.com'
                 ],
-                timeout=self._configuration.get('timeout')['ipv4_detection'],
+                timeout=self.entry_options.get('ipv4_timeout_secs', 1),
                 stderr=DEVNULL, universal_newlines=True
             ).rstrip()
         except (FileNotFoundError, TimeoutExpired, CalledProcessError):
             try:
                 ipv4_addr = urlopen(
                     'https://v4.ident.me/',
-                    timeout=self._configuration.get('timeout')['ipv4_detection']
+                    timeout=self.entry_options.get('ipv4_timeout_secs', 1)
                 )
             except (HTTPError, URLError, SocketTimeoutError):
                 # The machine does not seem to be connected to Internet...
@@ -54,14 +54,14 @@ class WanIp(Entry):
                     'dig', '+short', '-6', 'AAAA', 'myip.opendns.com',
                     '@resolver1.ipv6-sandbox.opendns.com'
                 ],
-                timeout=self._configuration.get('timeout')['ipv6_detection'],
+                timeout=self.entry_options.get('ipv6_timeout_secs', 1),
                 stderr=DEVNULL, universal_newlines=True
             ).rstrip()
         except (FileNotFoundError, TimeoutExpired, CalledProcessError):
             try:
                 response = urlopen(
                     'https://v6.ident.me/',
-                    timeout=self._configuration.get('timeout')['ipv6_detection']
+                    timeout=self.entry_options.get('ipv6_timeout_secs', 1)
                 )
             except (HTTPError, URLError, SocketTimeoutError):
                 # It looks like this machine doesn't have any IPv6 address...

--- a/archey/entries/wan_ip.py
+++ b/archey/entries/wan_ip.py
@@ -18,7 +18,7 @@ class WanIP(Entry):
         self._retrieve_ipv4_address()
 
         # IPv6 address retrieval (unless the user doesn't want it).
-        if self.entry_options.get('ipv6_support', True):
+        if self.options.get('ipv6_support', True):
             self._retrieve_ipv6_address()
 
         self.value = list(filter(None, self.value))
@@ -30,14 +30,14 @@ class WanIP(Entry):
                     'dig', '+short', '-4', 'A', 'myip.opendns.com',
                     '@resolver1.opendns.com'
                 ],
-                timeout=self.entry_options.get('ipv4_timeout_secs', 1),
+                timeout=self.options.get('ipv4_timeout_secs', 1),
                 stderr=DEVNULL, universal_newlines=True
             ).rstrip()
         except (FileNotFoundError, TimeoutExpired, CalledProcessError):
             try:
                 ipv4_addr = urlopen(
                     'https://v4.ident.me/',
-                    timeout=self.entry_options.get('ipv4_timeout_secs', 1)
+                    timeout=self.options.get('ipv4_timeout_secs', 1)
                 )
             except (HTTPError, URLError, SocketTimeoutError):
                 # The machine does not seem to be connected to Internet...
@@ -54,14 +54,14 @@ class WanIP(Entry):
                     'dig', '+short', '-6', 'AAAA', 'myip.opendns.com',
                     '@resolver1.ipv6-sandbox.opendns.com'
                 ],
-                timeout=self.entry_options.get('ipv6_timeout_secs', 1),
+                timeout=self.options.get('ipv6_timeout_secs', 1),
                 stderr=DEVNULL, universal_newlines=True
             ).rstrip()
         except (FileNotFoundError, TimeoutExpired, CalledProcessError):
             try:
                 response = urlopen(
                     'https://v6.ident.me/',
-                    timeout=self.entry_options.get('ipv6_timeout_secs', 1)
+                    timeout=self.options.get('ipv6_timeout_secs', 1)
                 )
             except (HTTPError, URLError, SocketTimeoutError):
                 # It looks like this machine doesn't have any IPv6 address...
@@ -79,5 +79,5 @@ class WanIP(Entry):
         # If not, fall-back on the "No address" string.
         output.append(
             self.name,
-            ', '.join(self.value) or self._configuration.get('default_strings')['no_address']
+            ', '.join(self.value) or self._default_strings.get('no_address')
         )

--- a/archey/entry.py
+++ b/archey/entry.py
@@ -10,17 +10,19 @@ class Entry(AbstractBaseClass):
     @abstractmethod
     def __init__(self, name=None, value=None, options=None):
         # Each entry will have always have the following attributes...
-        # `name`: key;
+        # `name`: key (defaults to the instantiated entry class name);
         # `value`: value of entry as an appropriate object;
-        # `options`: configuration options *specific* to an entry instance
-        # ... which are `None` by default.
-        self.name = name
+        # `options`: configuration options *specific* to an entry instance;
+        self.name = name or self.__class__.__name__
         self.value = value
-        self.entry_options = options or {}
+        self.options = options or {}
 
-        # Propagates a reference to `Configuration` singleton to each inheriting class.
-        self._configuration = Configuration()
+        # Propagates a reference to default strings specified in `Configuration`.
+        self._default_strings = Configuration().get('default_strings')
 
+    def __bool__(self):
+        """Makes an `Entry` evaluates to _falsy_ if `disabled` config field is _truthy_"""
+        return not bool(self.options.get('disabled'))
 
     def output(self, output):
         """Output the results to output. Can be overridden by subclasses."""
@@ -32,5 +34,5 @@ class Entry(AbstractBaseClass):
             # If the value is "falsy" leave a generic "Not detected" message for this entry.
             output.append(
                 self.name,
-                self._configuration.get('default_strings')['not_detected']
+                self._default_strings.get('not_detected')
             )

--- a/archey/entry.py
+++ b/archey/entry.py
@@ -8,13 +8,15 @@ from archey.configuration import Configuration
 class Entry(AbstractBaseClass):
     """Module base class"""
     @abstractmethod
-    def __init__(self, name=None, value=None):
+    def __init__(self, name=None, value=None, options=None):
         # Each entry will have always have the following attributes...
-        # `name` (key);
-        # `value` (value of entry as an appropriate object)
+        # `name`: key;
+        # `value`: value of entry as an appropriate object;
+        # `options`: configuration options *specific* to an entry instance
         # ... which are `None` by default.
         self.name = name
         self.value = value
+        self.entry_options = options or {}
 
         # Propagates a reference to `Configuration` singleton to each inheriting class.
         self._configuration = Configuration()

--- a/archey/output.py
+++ b/archey/output.py
@@ -38,7 +38,7 @@ class Output:
 
         # If `os-release`'s `ANSI_COLOR` option is set, honor it.
         ansi_color = Distributions.get_ansi_color()
-        if ansi_color and Configuration().get('colors_palette')['honor_ansi_color']:
+        if ansi_color and Configuration().get('honor_ansi_color'):
             # Replace each Archey integrated colors by `ANSI_COLOR`.
             self._colors_palette = len(self._colors_palette) * \
                 [Colors.escape_code_from_attrs(ansi_color)]

--- a/archey/test/entries/__init__.py
+++ b/archey/test/entries/__init__.py
@@ -17,7 +17,7 @@ class HelperMethods:
     We kindly borrow `update_recursive` class method from `Configuration` to DRY its implementation.
     """
     @staticmethod
-    def entry_mock(entry, configuration=None):
+    def entry_mock(entry, options=None, configuration=None):
         """
         Creates a placeholder "instance" of the entry class passed, with a clean default
         `_configuration` which is optionally updated by `configuration`.
@@ -34,6 +34,8 @@ class HelperMethods:
         # These instance-attributes are quite important, so let's mimic them.
         instance_mock.name = str(entry.__name__)
         instance_mock.value = None  # (entry default)
+        # We don't have default entry options defined outside of entries.
+        instance_mock.entry_options = options or {}
 
         # Let's initially give the entry configuration the defaults.
         # We deep-copy `DEFAULT_CONFIG` to prevent its mutation.
@@ -138,7 +140,10 @@ class TestHelperMethods(unittest.TestCase, HelperMethods):
                 'key_1': 10  # Updating a nested key-value pair.
             }
         }
-        simple_mock_instance = self.entry_mock(TestHelperMethods._SimpleEntry, configuration_dict)
+        simple_mock_instance = self.entry_mock(
+            TestHelperMethods._SimpleEntry,
+            configuration=configuration_dict
+        )
         self.assertDictEqual(
             simple_mock_instance._configuration,  # pylint: disable=protected-access
             {

--- a/archey/test/entries/test_archey_disk.py
+++ b/archey/test/entries/test_archey_disk.py
@@ -250,7 +250,7 @@ class TestDiskEntry(unittest.TestCase):
         self.output_mock.reset_mock()
 
         with self.subTest('Multi-line output'):
-            self.disk_instance_mock._configuration['disk']['combine_total'] = False  # pylint: disable=protected-access
+            self.disk_instance_mock.entry_options['combine_total'] = False
             Disk.output(self.disk_instance_mock, self.output_mock)
             self.assertEqual(self.output_mock.append.call_count, 2)
             self.output_mock.append.assert_has_calls(
@@ -270,8 +270,10 @@ class TestDiskEntry(unittest.TestCase):
         self.output_mock.reset_mock()
 
         with self.subTest('Entry name labeling (device path with entry name)'):
-            self.disk_instance_mock._configuration['disk']['combine_total'] = False  # pylint: disable=protected-access
-            self.disk_instance_mock._configuration['disk']['disk_labels'] = 'device_paths'  # pylint: disable=protected-access
+            self.disk_instance_mock.entry_options = {
+                'combine_total': False,
+                'disk_labels': 'device_paths'
+            }
 
             Disk.output(self.disk_instance_mock, self.output_mock)
             self.assertEqual(self.output_mock.append.call_count, 2)
@@ -292,9 +294,11 @@ class TestDiskEntry(unittest.TestCase):
         self.output_mock.reset_mock()
 
         with self.subTest('Entry name labeling (mount points without entry name)'):
-            self.disk_instance_mock._configuration['disk']['combine_total'] = False  # pylint: disable=protected-access
-            self.disk_instance_mock._configuration['disk']['disk_labels'] = 'mount_points'  # pylint: disable=protected-access
-            self.disk_instance_mock._configuration['disk']['hide_entry_name'] = True  # pylint: disable=protected-access
+            self.disk_instance_mock.entry_options = {
+                'combine_total': False,
+                'disk_labels': 'mount_points',
+                'hide_entry_name': True
+            }
 
             Disk.output(self.disk_instance_mock, self.output_mock)
             self.assertEqual(self.output_mock.append.call_count, 2)
@@ -315,10 +319,12 @@ class TestDiskEntry(unittest.TestCase):
         self.output_mock.reset_mock()
 
         with self.subTest('Entry name labeling (without disk label nor entry name)'):
-            self.disk_instance_mock._configuration['disk']['combine_total'] = False  # pylint: disable=protected-access
-            self.disk_instance_mock._configuration['disk']['disk_labels'] = False  # pylint: disable=protected-access
-            # `hide_entry_name` is being ignored as `disk_labels` evaluates to "falsy" too.
-            self.disk_instance_mock._configuration['disk']['hide_entry_name'] = True  # pylint: disable=protected-access
+            self.disk_instance_mock.entry_options = {
+                'combine_total': False,
+                'disk_labels': False,
+                # `hide_entry_name` is being ignored as `disk_labels` evaluates to "falsy" too.
+                'hide_entry_name': True
+            }
 
             Disk.output(self.disk_instance_mock, self.output_mock)
             self.assertEqual(self.output_mock.append.call_count, 2)

--- a/archey/test/entries/test_archey_disk.py
+++ b/archey/test/entries/test_archey_disk.py
@@ -147,7 +147,7 @@ class TestDiskEntry(unittest.TestCase):
     def test_disk_df_output_dict(self, _):
         """Test method to get `df` output as a dict by mocking calls to `check_output`."""
         self.assertDictEqual(
-            Disk.get_df_output_dict(),
+            Disk._get_df_output_dict(),  # pylint: disable=protected-access
             {
                 '/': {
                     'device_path': '/dev/nvme0n1p2',
@@ -169,7 +169,7 @@ class TestDiskEntry(unittest.TestCase):
 
         with self.subTest('Missing `df` from system.'):
             self.assertDictEqual(
-                Disk.get_df_output_dict(),
+                Disk._get_df_output_dict(),  # pylint: disable=protected-access
                 {}
             )
 
@@ -250,7 +250,7 @@ class TestDiskEntry(unittest.TestCase):
         self.output_mock.reset_mock()
 
         with self.subTest('Multi-line output'):
-            self.disk_instance_mock.entry_options['combine_total'] = False
+            self.disk_instance_mock.options['combine_total'] = False
             Disk.output(self.disk_instance_mock, self.output_mock)
             self.assertEqual(self.output_mock.append.call_count, 2)
             self.output_mock.append.assert_has_calls(
@@ -270,7 +270,7 @@ class TestDiskEntry(unittest.TestCase):
         self.output_mock.reset_mock()
 
         with self.subTest('Entry name labeling (device path with entry name)'):
-            self.disk_instance_mock.entry_options = {
+            self.disk_instance_mock.options = {
                 'combine_total': False,
                 'disk_labels': 'device_paths'
             }
@@ -294,7 +294,7 @@ class TestDiskEntry(unittest.TestCase):
         self.output_mock.reset_mock()
 
         with self.subTest('Entry name labeling (mount points without entry name)'):
-            self.disk_instance_mock.entry_options = {
+            self.disk_instance_mock.options = {
                 'combine_total': False,
                 'disk_labels': 'mount_points',
                 'hide_entry_name': True
@@ -319,7 +319,7 @@ class TestDiskEntry(unittest.TestCase):
         self.output_mock.reset_mock()
 
         with self.subTest('Entry name labeling (without disk label nor entry name)'):
-            self.disk_instance_mock.entry_options = {
+            self.disk_instance_mock.options = {
                 'combine_total': False,
                 'disk_labels': False,
                 # `hide_entry_name` is being ignored as `disk_labels` evaluates to "falsy" too.

--- a/archey/test/entries/test_archey_gpu.py
+++ b/archey/test/entries/test_archey_gpu.py
@@ -21,7 +21,6 @@ XX:YY.H SMBus: BBBBBBBBBBBBBBBB
 XX:YY.H VGA compatible controller: GPU-MODEL-NAME
 XX:YY.H Audio device: DDDDDDDDDDDDDDDD
 """)
-    @HelperMethods.patch_clean_configuration
     def test_match_vga(self, _):
         """Simple 'VGA' device type matching"""
         self.assertListEqual(GPU().value, ['GPU-MODEL-NAME'])
@@ -36,20 +35,16 @@ XX:YY.H Display controller: ANOTHER-MATCHING-VIDEO-CONTROLLER
 XX:YY.H Audio device: DDDDDDDDDDDDDDDD
 XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
 """)
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'gpu': {
-                'one_line': True,
-                'max_count': 2
-            }
-        }
-    )
     def test_multi_matches_capped_one_line(self, _):
         """
         Test detection when there are multiple graphical device candidates.
         Check that `max_count` and `one_line` are honored too, including on `output` overriding.
         """
-        gpu = GPU()
+        gpu = GPU(options={
+            'one_line': True,
+            'max_count': 2
+        })
+
 
         output_mock = MagicMock()
         gpu.output(output_mock)
@@ -72,20 +67,15 @@ XX:YY.H Display controller: ANOTHER-MATCHING-VIDEO-CONTROLLER
 XX:YY.H Audio device: DDDDDDDDDDDDDDDD
 XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
 """)
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'gpu': {
-                'one_line': False,
-                'max_count': False
-            }
-        }
-    )
     def test_multi_matches_uncapped_multiple_lines(self, _):
         """
         Test detection when there are multiple graphical device candidates.
         Check that `max_count` and `one_line` are honored too, including on `output` overriding.
         """
-        gpu = GPU()
+        gpu = GPU(options={
+            'one_line': False,
+            'max_count': False
+        })
 
         output_mock = MagicMock()
         gpu.output(output_mock)

--- a/archey/test/entries/test_archey_lan_ip.py
+++ b/archey/test/entries/test_archey_lan_ip.py
@@ -5,13 +5,13 @@ from unittest.mock import MagicMock, patch
 
 from netifaces import AF_INET, AF_INET6, AF_LINK
 
-from archey.entries.lan_ip import LanIp
+from archey.entries.lan_ip import LanIP
 from archey.test import CustomAssertions
 from archey.test.entries import HelperMethods
 from archey.constants import DEFAULT_CONFIG
 
 
-class TestLanIpEntry(unittest.TestCase, CustomAssertions):
+class TestLanIPEntry(unittest.TestCase, CustomAssertions):
     """Here, we mock the `netifaces` usages (interfaces and addresses detection calls)"""
     @patch(
         'archey.entries.lan_ip.netifaces.interfaces',
@@ -48,13 +48,12 @@ class TestLanIpEntry(unittest.TestCase, CustomAssertions):
             }
         ]
     )
-    @HelperMethods.patch_clean_configuration(
-        configuration={'ip_settings': {'lan_ip_max_count': False}}
-    )
     def test_multiple_interfaces(self, _, __):
         """Test for multiple interfaces, multiple addresses (including a loopback one)"""
         self.assertListEqual(
-            LanIp().value,
+            LanIP(options={
+                'max_count': False
+            }).value,
             ['192.168.0.11', '192.168.1.11', '172.34.56.78']
         )
 
@@ -107,20 +106,15 @@ class TestLanIpEntry(unittest.TestCase, CustomAssertions):
             }
         ]
     )
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'ip_settings': {
-                'lan_ip_max_count': 2,
-                'lan_ip_v6_support': True
-            }
-        }
-    )
     def test_ipv6_and_limit_and_ether(self, _, __):
         """
         Test for IPv6 support, final set length limit and Ethernet interface filtering.
         Additionally check the `output` method behavior.
         """
-        lan_ip = LanIp()
+        lan_ip = LanIP(options={
+            'max_count': 2,
+            'ipv6_support': True
+        })
 
         output_mock = MagicMock()
         lan_ip.output(output_mock)
@@ -175,13 +169,12 @@ class TestLanIpEntry(unittest.TestCase, CustomAssertions):
             }
         ]
     )
-    @HelperMethods.patch_clean_configuration(
-        configuration={'ip_settings': {'lan_ip_v6_support': False}}
-    )
     def test_no_ipv6(self, _, __):
         """Test for IPv6 hiding"""
         self.assertListEqual(
-            LanIp().value,
+            LanIP(options={
+                'ipv6_support': False
+            }).value,
             ['192.168.1.55']
         )
 
@@ -189,10 +182,9 @@ class TestLanIpEntry(unittest.TestCase, CustomAssertions):
         'archey.entries.lan_ip.netifaces.interfaces',
         return_value=[]  # No interface returned by `netifaces`.
     )
-    @HelperMethods.patch_clean_configuration
     def test_no_network_interface(self, _):
         """Test when the device does not have any network interface"""
-        self.assertListEmpty(LanIp().value)
+        self.assertListEmpty(LanIP().value)
 
     @patch(
         'archey.entries.lan_ip.netifaces.interfaces',
@@ -227,7 +219,7 @@ class TestLanIpEntry(unittest.TestCase, CustomAssertions):
         Test when the network interface(s) do not have any IP address.
         Additionally check the `output` method behavior.
         """
-        lan_ip = LanIp()
+        lan_ip = LanIP()
 
         output_mock = MagicMock()
         lan_ip.output(output_mock)
@@ -250,7 +242,7 @@ class TestLanIpEntry(unittest.TestCase, CustomAssertions):
     @HelperMethods.patch_clean_configuration
     def test_netifaces_not_available(self, _):
         """Check `netifaces` is really acting as a (soft-)dependency"""
-        lan_ip = LanIp()
+        lan_ip = LanIP()
 
         output_mock = MagicMock()
         lan_ip.output(output_mock)

--- a/archey/test/entries/test_archey_model.py
+++ b/archey/test/entries/test_archey_model.py
@@ -128,8 +128,8 @@ class TestModelEntry(unittest.TestCase):
             'MY-LAPTOP-MODEL'
         )
 
-    def test_fetch_rasperry_pi_revision(self):
-        """Test `_fetch_rasperry_pi_revision` static method"""
+    def test_fetch_raspberry_pi_revision(self):
+        """Test `_fetch_raspberry_pi_revision` static method"""
         with patch('archey.entries.model.open', mock_open(), create=True) as mock:
             mock.return_value.read.side_effect = [
                 'Hardware\t: HARDWARE\nRevision\t: REVISION\n',
@@ -137,11 +137,11 @@ class TestModelEntry(unittest.TestCase):
             ]
 
             self.assertEqual(
-                Model._fetch_rasperry_pi_revision(),  # pylint: disable=protected-access
+                Model._fetch_raspberry_pi_revision(),  # pylint: disable=protected-access
                 'Raspberry Pi HARDWARE (Rev. REVISION)'
             )
             self.assertIsNone(
-                Model._fetch_rasperry_pi_revision()  # pylint: disable=protected-access
+                Model._fetch_raspberry_pi_revision()  # pylint: disable=protected-access
             )
 
     @patch(
@@ -171,7 +171,7 @@ class TestModelEntry(unittest.TestCase):
         return_value=None  # No model name could be retrieved...
     )
     @patch(
-        'archey.entries.model.Model._fetch_rasperry_pi_revision',
+        'archey.entries.model.Model._fetch_raspberry_pi_revision',
         return_value=None  # Not a Raspberry Pi device either...
     )
     @patch(

--- a/archey/test/entries/test_archey_ram.py
+++ b/archey/test/entries/test_archey_ram.py
@@ -21,20 +21,13 @@ class TestRAMEntry(unittest.TestCase):
 Mem:          15658        2043       10232          12        3382       13268
 Swap:          4095          39        4056
 """)
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'limits': {
-                'ram': {
-                    'warning': 25,
-                    'danger': 45
-                }
-            }
-        }
-    )
     def test_free_dash_m(self, _):
         """Test `free -m` output parsing for low RAM use case"""
         output_mock = MagicMock()
-        RAM().output(output_mock)
+        RAM(options={
+            'warning': 25,
+            'danger': 45
+        }).output(output_mock)
         self.assertEqual(
             output_mock.append.call_args[0][1],
             '{0}2043 MiB{1} / 15658 MiB'.format(
@@ -50,20 +43,13 @@ Swap:          4095          39        4056
 Mem:       7412     3341    1503       761        2567        3011
 Swap:      7607        5    7602
 """)
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'limits': {
-                'ram': {
-                    'warning': 33.3,
-                    'danger': 66.7
-                }
-            }
-        }
-    )
     def test_free_dash_m_warning(self, _):
         """Test `free -m` output parsing for warning RAM use case"""
         output_mock = MagicMock()
-        RAM().output(output_mock)
+        RAM(options={
+            'warning': 33.3,
+            'danger': 66.7
+        }).output(output_mock)
         self.assertEqual(
             output_mock.append.call_args[0][1],
             '{0}3341 MiB{1} / 7412 MiB'.format(
@@ -79,20 +65,13 @@ Swap:      7607        5    7602
 Mem:          15658       12341         624         203        2692        2807
 Swap:          4095         160        3935
 """)
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'limits': {
-                'ram': {
-                    'warning': 33.3,
-                    'danger': 66.7
-                }
-            }
-        }
-    )
     def test_free_dash_m_danger(self, _):
         """Test `free -m` output parsing for danger RAM use case"""
         output_mock = MagicMock()
-        RAM().output(output_mock)
+        RAM(options={
+            'warning': 25,
+            'danger': 45
+        }).output(output_mock)
         self.assertEqual(
             output_mock.append.call_args[0][1],
             '{0}12341 MiB{1} / 15658 MiB'.format(

--- a/archey/test/entries/test_archey_temperature.py
+++ b/archey/test/entries/test_archey_temperature.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock, patch
 
 
 from archey.entries.temperature import Temperature
-from archey.test.entries import HelperMethods
 
 
 class TestTemperatureEntry(unittest.TestCase):
@@ -49,21 +48,16 @@ class TestTemperatureEntry(unittest.TestCase):
         'archey.entries.temperature.iglob',
         return_value=[]  # No temperature from file will be retrieved
     )
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'temperature': {
-                'sensors_chipsets': [],
-                'use_fahrenheit': False,
-                'char_before_unit': ' '
-            }
-        }
-    )
     def test_vcgencmd_only_no_max(self, _, __):
         """
         Test for `vcgencmd` output only (no sensor files).
         Only one value is retrieved, so no maximum should be displayed (see #39).
         """
-        temperature = Temperature()
+        temperature = Temperature(options={
+            'sensors_chipsets': [],
+            'use_fahrenheit': False,
+            'char_before_unit': ' '
+        })
 
         output_mock = MagicMock()
         temperature.output(output_mock)
@@ -90,20 +84,15 @@ class TestTemperatureEntry(unittest.TestCase):
         ]
     )
     @patch('archey.entries.temperature.iglob')
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'temperature': {
-                'sensors_chipsets': [],
-                'use_fahrenheit': False,
-                'char_before_unit': ' '
-            }
-        }
-    )
     def test_vcgencmd_and_files(self, iglob_mock, _):
         """Tests `vcgencmd` output AND sensor files"""
         iglob_mock.return_value = iter([file.name for file in self._temp_files])
         self.assertDictEqual(
-            Temperature().value,
+            Temperature(options={
+                'sensors_chipsets': [],
+                'use_fahrenheit': False,
+                'char_before_unit': ' '
+            }).value,
             {
                 'temperature': 45.0,
                 'max_temperature': 50.0,
@@ -120,20 +109,15 @@ class TestTemperatureEntry(unittest.TestCase):
         ]
     )
     @patch('archey.entries.temperature.iglob')
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'temperature': {
-                'sensors_chipsets': [],
-                'use_fahrenheit': True,
-                'char_before_unit': '@'
-            }
-        }
-    )
     def test_files_only_in_fahrenheit(self, iglob_mock, _):
         """Test sensor files only, Fahrenheit (naive) conversion and special degree character"""
         iglob_mock.return_value = iter([file.name for file in self._temp_files])
         self.assertDictEqual(
-            Temperature().value,
+            Temperature(options={
+                'sensors_chipsets': [],
+                'use_fahrenheit': True,
+                'char_before_unit': '@'
+            }).value,
             {
                 'temperature': 116.0,      # 46.7 degrees C in Fahrenheit.
                 'max_temperature': 122.0,  # 50 degrees C in Fahrenheit
@@ -153,12 +137,11 @@ class TestTemperatureEntry(unittest.TestCase):
         'archey.entries.temperature.iglob',
         return_value=[]  # No temperature from file will be retrieved.
     )
-    @HelperMethods.patch_clean_configuration(
-        configuration={'temperature': {'sensors_chipsets': []}}
-    )
     def test_no_output(self, _, __):
         """Test when no value could be retrieved (anyhow)"""
-        self.assertIsNone(Temperature().value)
+        self.assertIsNone(Temperature(options={
+            'sensors_chipsets': []
+        }).value)
 
     @patch(
         'archey.entries.temperature.check_output',  # Mock the `sensors` call.
@@ -221,19 +204,14 @@ class TestTemperatureEntry(unittest.TestCase):
             FileNotFoundError()  # No temperature from `vcgencmd` call.
         ]
     )
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'temperature': {
-                'sensors_chipsets': [],
-                'use_fahrenheit': True,
-                'char_before_unit': ' '
-            }
-        }
-    )
     def test_sensors_only_in_fahrenheit(self, _):
         """Test computations around `sensors` output and Fahrenheit (naive) conversion"""
         self.assertDictEqual(
-            Temperature().value,
+            Temperature(options={
+                'sensors_chipsets': [],
+                'use_fahrenheit': True,
+                'char_before_unit': ' '
+            }).value,
             {
                 'temperature': 126.6,      # (52.6 C in F)
                 'max_temperature': 237.2,  # (114.0 C in F)
@@ -250,20 +228,15 @@ class TestTemperatureEntry(unittest.TestCase):
         ]
     )
     @patch('archey.entries.temperature.iglob')
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'temperature': {
-                'sensors_chipsets': [],
-                'use_fahrenheit': False,
-                'char_before_unit': 'o'
-            }
-        }
-    )
     def test_sensors_error_1(self, iglob_mock, _):
         """Test `sensors` (hard) failure handling and polling from files in Celsius"""
         iglob_mock.return_value = iter([file.name for file in self._temp_files])
 
-        temperature = Temperature()
+        temperature = Temperature(options={
+            'sensors_chipsets': [],
+            'use_fahrenheit': False,
+            'char_before_unit': 'o'
+        })
 
         output_mock = MagicMock()
         temperature.output(output_mock)
@@ -296,20 +269,15 @@ class TestTemperatureEntry(unittest.TestCase):
         ]
     )
     @patch('archey.entries.temperature.iglob')
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'temperature': {
-                'sensors_chipsets': [],
-                'use_fahrenheit': False,
-                'char_before_unit': 'o'
-            }
-        }
-    )
     def test_sensors_error_2(self, iglob_mock, _):
         """Test `sensors` (hard) failure handling and polling from files in Celsius"""
         iglob_mock.return_value = iter([file.name for file in self._temp_files])
         self.assertDictEqual(
-            Temperature().value,
+            Temperature(options={
+                'sensors_chipsets': [],
+                'use_fahrenheit': False,
+                'char_before_unit': 'o'
+            }).value,
             {
                 'temperature': 46.7,
                 'max_temperature': 50.0,
@@ -329,7 +297,6 @@ class TestTemperatureEntry(unittest.TestCase):
         'archey.entries.temperature.iglob',
         return_value=[]  # No temperature from file will be retrieved.
     )
-    @HelperMethods.patch_clean_configuration
     def test_celsius_to_fahrenheit_conversion(self, _, __):
         """Simple tests for the `_convert_to_fahrenheit` static method"""
         test_conversion_cases = [

--- a/archey/test/entries/test_archey_terminal.py
+++ b/archey/test/entries/test_archey_terminal.py
@@ -26,7 +26,6 @@ class TestTerminalEntry(unittest.TestCase):
         },
         clear=True
     )
-    @HelperMethods.patch_clean_configuration
     def test_terminal_emulator_term_program(self):
         """Check that `TERM_PROGRAM` is honored even if `TERM` or `COLORTERM` is defined"""
         self.assertEqual(Terminal().value, 'A-COOL-TERMINAL-EMULATOR')
@@ -39,7 +38,6 @@ class TestTerminalEntry(unittest.TestCase):
         },
         clear=True
     )
-    @HelperMethods.patch_clean_configuration
     def test_terminal_emulator_special_term(self):
         """Check that `TERM` is honored even if a "known identifier" could be found"""
         self.assertEqual(Terminal().value, 'OH-A-SPECIAL-CASE')
@@ -52,7 +50,6 @@ class TestTerminalEntry(unittest.TestCase):
         },
         clear=True
     )
-    @HelperMethods.patch_clean_configuration
     def test_terminal_emulator_name_normalization(self):
         """Check that our manual terminal detection as long as name normalization are working"""
         self.assertEqual(Terminal().value, 'Konsole')
@@ -83,7 +80,6 @@ class TestTerminalEntry(unittest.TestCase):
         {'COLORTERM': 'kmscon'},
         clear=True
     )
-    @HelperMethods.patch_clean_configuration
     def test_terminal_emulator_colorterm(self):
         """Check we can detect terminals using the `COLORTERM` environment variable."""
         self.assertEqual(Terminal().value, 'KMSCON')
@@ -97,7 +93,6 @@ class TestTerminalEntry(unittest.TestCase):
         },
         clear=True
     )
-    @HelperMethods.patch_clean_configuration
     def test_terminal_emulator_colorterm_override(self):
         """
         Check we observe terminal using `COLORTERM` even if `TERM` or a "known identifier" is found.
@@ -131,6 +126,7 @@ class TestTerminalEntry(unittest.TestCase):
         {},
         clear=True
     )
+    @HelperMethods.patch_clean_configuration
     def test_not_detected(self):
         """Test terminal emulator (non-)detection, without Unicode support"""
         terminal = Terminal(options={'use_unicode': False})
@@ -140,7 +136,9 @@ class TestTerminalEntry(unittest.TestCase):
         output = output_mock.append.call_args[0][1]
 
         self.assertIsNone(terminal.value)
-        self.assertTrue(output.startswith(DEFAULT_CONFIG['default_strings']['not_detected']))
+        self.assertTrue(
+            output.startswith(DEFAULT_CONFIG['default_strings']['not_detected'])
+        )
         self.assertFalse(output.count('\u2588'))
 
 

--- a/archey/test/entries/test_archey_terminal.py
+++ b/archey/test/entries/test_archey_terminal.py
@@ -62,16 +62,9 @@ class TestTerminalEntry(unittest.TestCase):
         {'TERM': 'xterm-256color'},
         clear=True
     )
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'colors_palette': {
-                'use_unicode': True
-            }
-        }
-    )
     def test_terminal_emulator_term_fallback_and_unicode(self):
         """Check that `TERM` is honored if present, and Unicode support for the colors palette"""
-        terminal = Terminal()
+        terminal = Terminal(options={'use_unicode': True})
 
         output_mock = MagicMock()
         terminal.output(output_mock)
@@ -138,16 +131,9 @@ class TestTerminalEntry(unittest.TestCase):
         {},
         clear=True
     )
-    @HelperMethods.patch_clean_configuration(
-        configuration={
-            'colors_palette': {
-                'use_unicode': False
-            }
-        }
-    )
     def test_not_detected(self):
         """Test terminal emulator (non-)detection, without Unicode support"""
-        terminal = Terminal()
+        terminal = Terminal(options={'use_unicode': False})
 
         output_mock = MagicMock()
         terminal.output(output_mock)

--- a/archey/test/test_archey_entry.py
+++ b/archey/test/test_archey_entry.py
@@ -24,11 +24,19 @@ class TestEntry(unittest.TestCase):
         self.assertTrue(issubclass(_SimpleEntry, Entry))
         self.assertRaises(TypeError, Entry)
 
+    def test_entry_boolean_evaluation(self):
+        """Test `Entry` boolean evaluation"""
+        simple_entry = _SimpleEntry()
+        self.assertTrue(simple_entry)
+
+        simple_entry = _SimpleEntry(options={'disabled': True})
+        self.assertFalse(simple_entry)
+
     def test_entry_usage(self):
         """Test `Entry` instantiation and parameters passing"""
         simple_entry = _SimpleEntry()
-        self.assertFalse(simple_entry.name)
-        self.assertFalse(simple_entry.value)
+        self.assertEqual(simple_entry.name, '_SimpleEntry')
+        self.assertIsNone(simple_entry.value)
 
         simple_entry = _SimpleEntry('T', 'est')
         self.assertEqual(simple_entry.name, 'T')

--- a/archey/test/test_archey_output.py
+++ b/archey/test/test_archey_output.py
@@ -28,8 +28,10 @@ class TestOutputUtil(unittest.TestCase):
         {Distributions.DEBIAN: ['COLOR_0']}
     )
     @patch(
-        'archey.output.Configuration.get',
-        return_value={'honor_ansi_color': False}
+        'archey.output.Configuration.get',  # Disable `honor_ansi_color` option.
+        side_effect=(
+            lambda config_key: not (config_key == 'honor_ansi_color')
+        )
     )
     def test_append_regular(self, _, __):
         """Test the `append` method, for new entries"""
@@ -50,8 +52,10 @@ class TestOutputUtil(unittest.TestCase):
         return_value='ANSI_COLOR'
     )
     @patch(
-        'archey.output.Configuration.get',
-        return_value={'honor_ansi_color': True}
+        'archey.output.Configuration.get',  # Enable `honor_ansi_color` option.
+        side_effect=(
+            lambda config_key: config_key == 'honor_ansi_color'
+        )
     )
     def test_append_ansi_color(self, _, __, ___):
         """Check that `Output` honor `ANSI_COLOR` as required"""
@@ -75,8 +79,10 @@ class TestOutputUtil(unittest.TestCase):
         return_value='ANSI_COLOR'
     )
     @patch(
-        'archey.output.Configuration.get',
-        return_value={'honor_ansi_color': False}
+        'archey.output.Configuration.get',  # Disable `honor_ansi_color` option.
+        side_effect=(
+            lambda config_key: not (config_key == 'honor_ansi_color')
+        )
     )
     def test_append_no_ansi_color(self, _, __, ___):
         """Check that `Output` DOES NOT honor `ANSI_COLOR` when specified"""
@@ -339,8 +345,10 @@ O \x1b[0;31m\x1b[0m...\x1b[0m\
         return_value=Distributions.DEBIAN  # Make Debian being selected.
     )
     @patch(
-        'archey.output.Configuration.get',
-        return_value={'honor_ansi_color': False}
+        'archey.output.Configuration.get',  # Disable `honor_ansi_color` option.
+        side_effect=(
+            lambda config_key: not (config_key == 'honor_ansi_color')
+        )
     )
     @patch(
         'archey.output.print',


### PR DESCRIPTION
## Description
This PR is is to enable configuration rearrangement, as in #57.

Apologies that this is in the form of a single squashed commit... however I rebased this branch quite a lot of times and the history was a mess, so it got squashed into one.

While I've provided an implementation here, if you don't think it's suitable we can also use this PR to discuss an alternative.

## Reason and / or context
See #57.

## Changes
* Configuration completely rearranged.
  * Entries are now specified as `dict`s containing their `type` and ~~`options` keys~~ respective options.
  * All entry-specific options are in the entry's definition thing.
  * Entries can be specified multiple times with different options as a side-effect of this. I may or may not have a plan to try out custom-defined entries with this... 😆 
* All `Entry` subclasses now have ~~`entry_options`~~ `options` as an attribute, which contains the entry-specific options.
* The main global configuration now contains configuration only globally applicable.

**These changes are all breaking** to anybody with a configuration file (as it will now be unusable and crash Archey 😦). This could be very similarly implemented using entries' options as dict values on the keys already present, however this won't allow for the multiple-entry specifying I mentioned earlier.

Alternatively, we could add code to handle old configuration files... With a warning to update it, or automatically convert it to this format? This is still pretty awkard though.

## How has this been tested ?
* Still runs on all of my systems fine as far as I can tell.
* All unit tests are passing (after some modification, but nothing breaking).

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- [X] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
