### PR TITLE
[FEATURE] Honors `NO_COLOR` when set

### DIFF
--- a/archey/colors.py
+++ b/archey/colors.py
@@ -39,9 +39,6 @@ class Colors(Enum):
     WHITE_BRIGHT = (1, 37)
 
     def __str__(self):
-        if NO_COLOR:
-            return ''
-
         return self.escape_code_from_attrs(
             ';'.join(map(str, self.value))
         )
@@ -51,6 +48,9 @@ class Colors(Enum):
         """
         Build and return an ANSI/ECMA-48 escape code string from passed display attributes.
         """
+        if NO_COLOR:
+            return ''
+
         return '\x1b[{}m'.format(display_attrs)
 
     @staticmethod

--- a/archey/colors.py
+++ b/archey/colors.py
@@ -3,11 +3,16 @@
 from bisect import bisect
 from enum import Enum
 
+import os
 import re
 
 
 # REGEXP compiled pattern matching ANSI/ECMA-48 color escape codes.
 ANSI_ECMA_REGEXP = re.compile(r'\x1b\[\d+(?:(?:;\d+)+)?m')
+
+# Let's honor `NO_COLOR` if set.
+# See <https://no-color.org/>.
+NO_COLOR = ('NO_COLOR' in os.environ)
 
 
 class Colors(Enum):
@@ -34,6 +39,9 @@ class Colors(Enum):
     WHITE_BRIGHT = (1, 37)
 
     def __str__(self):
+        if NO_COLOR:
+            return ''
+
         return self.escape_code_from_attrs(
             ';'.join(map(str, self.value))
         )
@@ -43,7 +51,7 @@ class Colors(Enum):
         """
         Build and return an ANSI/ECMA-48 escape code string from passed display attributes.
         """
-        return "\x1b[{}m".format(display_attrs)
+        return '\x1b[{}m'.format(display_attrs)
 
     @staticmethod
     def get_level_color(value, yellow_bpt, red_bpt):

--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -3,7 +3,7 @@
 import os
 import re
 
-from archey.colors import Colors
+from archey.colors import Colors, NO_COLOR
 from archey.entry import Entry
 
 
@@ -117,10 +117,8 @@ class Terminal(Entry):
 
     def output(self, output):
         """Adds the entry to `output` after pretty-formatting with colors palette"""
-        output.append(
-            self.name,
-            '{0} {1}'.format(
-                (self.value or self._configuration.get('default_strings')['not_detected']),
-                self._get_colors_palette()
-            )
-        )
+        text_output = (self.value or self._configuration.get('default_strings')['not_detected'])
+        if not NO_COLOR:
+            text_output += ' ' + self._get_colors_palette()
+
+        output.append(self.name, text_output)

--- a/archey/test/entries/test_archey_terminal.py
+++ b/archey/test/entries/test_archey_terminal.py
@@ -8,6 +8,10 @@ from archey.test.entries import HelperMethods
 from archey.constants import DEFAULT_CONFIG
 
 
+@patch(
+    'archey.entries.terminal.NO_COLOR',
+    False  # By default, colors won't be disabled.
+)
 class TestTerminalEntry(unittest.TestCase):
     """
     For this entry, we'll verify that the output contains what the environment
@@ -106,6 +110,28 @@ class TestTerminalEntry(unittest.TestCase):
         Check we observe terminal using `COLORTERM` even if `TERM` or a "known identifier" is found.
         """
         self.assertEqual(Terminal().value, 'KMSCON')
+
+    @patch.dict(
+        'archey.entries.terminal.os.environ',
+        {'TERM_PROGRAM': 'X-TERMINAL-EMULATOR'},
+        clear=True
+    )
+    def test_no_color(self):
+        """Test `Terminal` output behavior when `NO_COLOR` is set (palette should be hidden)"""
+        with patch(
+                'archey.entries.terminal.NO_COLOR',
+                True  # Temporary disable color for this test.
+            ):
+            terminal = Terminal()
+
+            output_mock = MagicMock()
+            terminal.output(output_mock)
+
+            self.assertEqual(terminal.value, 'X-TERMINAL-EMULATOR')
+            self.assertEqual(
+                output_mock.append.call_args[0][1],
+                'X-TERMINAL-EMULATOR'
+            )
 
     @patch.dict(
         'archey.entries.terminal.os.environ',

--- a/archey/test/test_archey_colors.py
+++ b/archey/test/test_archey_colors.py
@@ -1,10 +1,15 @@
 """Test module for `archey.colors`"""
 
 import unittest
+from unittest.mock import patch
 
 from archey.colors import ANSI_ECMA_REGEXP, Colors
 
 
+@patch(
+    'archey.colors.NO_COLOR',
+    False  # By default, colors won't be disabled.
+)
 class TestColorsUtil(unittest.TestCase):
     """Test cases for the `Colors` (enumeration / utility) class"""
     def test_constant_values(self):
@@ -62,6 +67,14 @@ class TestColorsUtil(unittest.TestCase):
             Colors.remove_colors('\x1b[0nTEST\xde\xad\xbe\xaf'),
             '\x1b[0nTEST\xde\xad\xbe\xaf'
         )
+
+    def test_no_color(self):
+        """Test `Colors` behavior when `NO_COLOR` is set"""
+        with patch(
+                'archey.colors.NO_COLOR',
+                True  # Temporary disable color for this test.
+            ):
+            self.assertFalse(str(Colors.CYAN_NORMAL))
 
 
 if __name__ == '__main__':

--- a/archey/test/test_archey_output.py
+++ b/archey/test/test_archey_output.py
@@ -11,6 +11,10 @@ from archey.output import Output
 from archey.distributions import Distributions
 
 
+@patch(
+    'archey.colors.NO_COLOR',
+    False  # By default, colors won't be disabled.
+)
 class TestOutputUtil(unittest.TestCase):
     """
     Simple test cases to check the behavior of the `Output` class.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This patch suppresses colors from text output when `NO_COLOR` environment variable is set.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
See <https://no-color.org/>.

## How has this been tested ?
<!--- Include details of your testing environment here -->
```bash
python3 -m unittest
NO_COLOR=1 python3 -m unittest
```

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
