### PR TITLE
[META] Adds official support for Python 3.10

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,10 +41,10 @@ jobs:
           time archey
           time python -m archey
 
-      # Currently disabled against Python 3.9.
+      # Currently disabled against Python >= 3.9.
       # See PyCQA/pylint#3882 & PyCQA/pylint#3890.
       - name: Lint source code against Pylint
-        if: ${{ matrix.python-version != '3.9' }}
+        if: ${{ matrix.python-version != '3.9' && matrix.python-version != '3.10-dev' }}
         run: pylint archey/
 
       # Disabled against Pypy (see python/typed_ast#111).

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version:
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10-dev'
+          - 'pypy3'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,8 +71,9 @@ jobs:
           rm dist/archey
 
       # Disabled against PyPy (see <https://stackoverflow.com/a/22245203>).
+      # Currently disabled against Python 3.10.
       - name: Standalone building (with PyInstaller)
-        if: ${{ matrix.python-version != 'pypy3' }}
+        if: ${{ matrix.python-version != 'pypy3' && matrix.python-version != '3.10-dev' }}
         run: |
           pyinstaller \
             --distpath dist \

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -35,7 +35,7 @@ NAME="$(python3 setup.py --name)"
 VERSION="$(python3 setup.py --version)"
 AUTHOR="$(python3 setup.py --author)"
 AUTHOR_EMAIL="$(python3 setup.py --author-email)"
-SUPPORTED_PYTHON_VERSIONS="$(python3 setup.py --classifiers | grep 'Programming Language' | grep -Po '\d\.\d')"
+SUPPORTED_PYTHON_VERSIONS="$(python3 setup.py --classifiers | grep 'Programming Language' | grep -Po '\d+\.\d+')"
 
 
 # DRY.

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ Remain *maintained*, *community-driven* and *highly-compatible* with yesterday's
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: System'
     ]
 )


### PR DESCRIPTION
## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
Python 3.10 is out, we should test Archey against it.

## How has this been tested ?
<!--- Include details of your testing environment here -->
Thanks to CI, one day, maybe.

> ~~:warning: Build is currently broken due to one of Pylint's depedencies.  
> `lazy-object-proxy` requires a Wheel to be built, but due to pypa/wheel#354 (see also pypa/packaging#308 & <https://bugs.python.org/issue40747>), the operation fails.  
> Currently keeping this PR as draft while waiting for the fix (python/cpython#20333 or python/cpython#22858) to be accepted.~~

> Pylint and Pyinstaller have been disabled in CI though (not yet compatible).

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
