### PR TITLE
[CPU] [FEATURE/BREAKING] Multiple CPUs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,10 @@ Below stand further descriptions for each available (default) option :
 		},
 		{
 			"type": "CPU",
+			// Set to `false` to display CPUs on multiple lines.
+			"one_line": true,
+			// Set to `false` to hide the number of cores.
+			"show_count": true,
 			//
 			// As explained above, you may rename entries as you wish.
 			//"name": "Processor"

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Below stand further descriptions for each available (default) option :
 			// Set to `true` to join all CPUs on the same line.
 			"one_line": false,
 			// Set to `false` to hide the number of cores.
-			"show_count": true,
+			"show_cores": true,
 			//
 			// As explained above, you may rename entries as you wish.
 			//"name": "Processor"

--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ Below stand further descriptions for each available (default) option :
 		},
 		{
 			"type": "CPU",
-			// Set to `false` to display CPUs on multiple lines.
-			"one_line": true,
+			// Set to `true` to join all CPUs on the same line.
+			"one_line": false,
 			// Set to `false` to hide the number of cores.
 			"show_count": true,
 			//
@@ -260,8 +260,8 @@ Below stand further descriptions for each available (default) option :
 		},
 		{
 			"type": "GPU",
-			// Set to `false` to display GPUs on multiple lines.
-			"one_line": true,
+			// Set to `true` to join all GPUs on the same line.
+			"one_line": false,
 			// The maximum number of GPUs you want to display.
 			// `false` --> Unlimited.
 			"max_count": 2

--- a/archey/entries/cpu.py
+++ b/archey/entries/cpu.py
@@ -9,40 +9,94 @@ from archey.entry import Entry
 
 class CPU(Entry):
     """
-    Parse `/proc/cpuinfo` file to retrieve the model name.
-    If no information could be retrieved, calls `lscpu`.
+    Parse `/proc/cpuinfo` file to retrieve model names.
+    If no information could be retrieved, call `lscpu`.
+
+    `value` attribute is populated as a `dict`.
+    It means that for Python < 3.6, "physical" CPU order **MAY** be lost.
     """
     _MODEL_NAME_REGEXP = re.compile(
         r'^model name\s*:\s*(.*)$',
+        flags=re.IGNORECASE | re.MULTILINE
+    )
+    _CPUS_COUNT_REGEXP = re.compile(
+        r'^CPU\(s\)\s*:\s*(\d+)$',
         flags=re.IGNORECASE | re.MULTILINE
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        cpuinfo_match = self._read_proc_cpuinfo()
-        if not cpuinfo_match:
+        self.value = self._parse_proc_cpuinfo()
+        if not self.value:
             # This test case has been built for some ARM architectures (see #29).
             # Sometimes, `model name` info is not present within `/proc/cpuinfo`.
             # We use the output of `lscpu` program (util-linux-ng) to retrieve it.
-            cpuinfo_match = self._run_lscpu()
+            self.value = self._parse_lscpu_output()
 
-        # Sometimes CPU model name contains extra ugly white-spaces.
-        self.value = re.sub(r'\s+', ' ', cpuinfo_match.group(1))
 
-    def _read_proc_cpuinfo(self):
-        """Read `/proc/cpuinfo` and search for our model name pattern"""
+    @classmethod
+    def _parse_proc_cpuinfo(cls):
+        """Read `/proc/cpuinfo` and search for CPU model names occurrences"""
         try:
             with open('/proc/cpuinfo') as f_cpu_info:
-                return self._MODEL_NAME_REGEXP.search(f_cpu_info.read())
+                cpu_models = cls._MODEL_NAME_REGEXP.findall(f_cpu_info.read())
         except (PermissionError, FileNotFoundError):
-            return None
+            return {}
 
-    def _run_lscpu(self):
+        # Manually de-duplicates CPUs count.
+        cpu_info = {}
+        for cpu_model in cpu_models:
+            # Sometimes CPU model names contain extra ugly white-spaces.
+            cpu_model = re.sub(r'\s+', ' ', cpu_model)
+
+            if cpu_model not in cpu_info:
+                cpu_info[cpu_model] = 1
+            else:
+                cpu_info[cpu_model] += 1
+
+        return cpu_info
+
+    @classmethod
+    def _parse_lscpu_output(cls):
         """Same operation but from `lscpu` output"""
-        return self._MODEL_NAME_REGEXP.search(
-            check_output(
-                ['lscpu'],
-                env={'LANG': 'C'}, universal_newlines=True
-            )
+        cpu_info = check_output(
+            ['lscpu'],
+            env={'LANG': 'C'}, universal_newlines=True
         )
+
+        cpu_models = cls._MODEL_NAME_REGEXP.findall(cpu_info)
+        cpu_counts = cls._CPUS_COUNT_REGEXP.findall(cpu_info)
+
+        return {
+            # Sometimes CPU model names contain extra ugly white-spaces.
+            re.sub(r'\s+', ' ', cpu_model): int(cpu_count)
+            for cpu_model, cpu_count in zip(cpu_models, cpu_counts)
+        }
+
+
+    def output(self, output):
+        """Writes CPUs to `output` based on preferences"""
+        def _pre_format(cpu_model, cpu_count):
+            """Simple closure to format our CPU final entry content"""
+            if cpu_count > 1 and self.options.get('show_count', True):
+                return '{} x {}'.format(cpu_count, cpu_model)
+
+            return cpu_model
+
+        # No CPU could be detected.
+        if not self.value:
+            output.append(self.name, self._default_strings.get('not_detected'))
+        # One-line output is enabled : Join the results !
+        elif self.options.get('one_line', True):
+            output.append(
+                self.name,
+                ', '.join([
+                    _pre_format(cpu_model, cpu_count)
+                    for cpu_model, cpu_count in self.value.items()
+                ])
+            )
+        # One-line output has been disabled, add one entry per item.
+        else:
+            for cpu_model, cpu_count in self.value.items():
+                output.append(self.name, _pre_format(cpu_model, cpu_count))

--- a/archey/entries/cpu.py
+++ b/archey/entries/cpu.py
@@ -117,7 +117,7 @@ class CPU(Entry):
                 else:
                     entries.append(model_name)
 
-        if self.options.get('one_line', True):
+        if self.options.get('one_line'):
             # One-line output is enabled : Join the results !
             output.append(self.name, ', '.join(entries))
         else:

--- a/archey/entries/cpu.py
+++ b/archey/entries/cpu.py
@@ -112,7 +112,7 @@ class CPU(Entry):
         entries = []
         for cpus in self.value:
             for model_name, cpu_count in cpus.items():
-                if cpu_count > 1 and self.options.get('show_count', True):
+                if cpu_count > 1 and self.options.get('show_cores', True):
                     entries.append('{} x {}'.format(cpu_count, model_name))
                 else:
                     entries.append(model_name)

--- a/archey/entries/gpu.py
+++ b/archey/entries/gpu.py
@@ -41,12 +41,14 @@ class GPU(Entry):
 
     def output(self, output):
         """Writes GPUs to `output` based on preferences"""
-        # Even when no GPU device could be detected, be sure to add an "empty" entry to `output`.
-        if self.options.get('one_line', True) or not self.value:
-            output.append(
-                self.name,
-                (', '.join(self.value) or self._default_strings.get('not_detected'))
-            )
+        # No GPU could be detected.
+        if not self.value:
+            output.append(self.name, self._default_strings.get('not_detected'))
+            return
+
+        # Join the results only if `one_line` option is enabled.
+        if self.options.get('one_line'):
+            output.append(self.name, ', '.join(self.value))
         else:
             for gpu_device in self.value:
                 output.append(self.name, gpu_device)

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -1,5 +1,6 @@
 """Test module for Archey's CPU detection module"""
 
+import sys
 import unittest
 from unittest.mock import MagicMock, call, mock_open, patch
 
@@ -157,7 +158,7 @@ Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
 
     @HelperMethods.patch_clean_configuration
     def test_various_output_configuration(self):
-        """Test (non-)detection when there is not any graphical candidate"""
+        """Test `output` overloading based on user preferences combination"""
         cpu_instance_mock = HelperMethods.entry_mock(CPU)
         output_mock = MagicMock()
 
@@ -167,6 +168,9 @@ Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
         }
 
         with self.subTest('Single-line combined output.'):
+            if sys.version_info < (3, 6):
+                self.skipTest("Cannot test behavior on Python < 3.6, skipping.")
+
             CPU.output(cpu_instance_mock, output_mock)
             output_mock.append.assert_called_once_with(
                 'CPU',
@@ -176,6 +180,9 @@ Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
         output_mock.reset_mock()
 
         with self.subTest('Single-line combined output (no count).'):
+            if sys.version_info < (3, 6):
+                self.skipTest("Cannot test behavior on Python < 3.6, skipping.")
+
             cpu_instance_mock.options['show_count'] = False
 
             CPU.output(cpu_instance_mock, output_mock)

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -1,15 +1,15 @@
 """Test module for Archey's CPU detection module"""
 
-import sys
 import unittest
 from unittest.mock import MagicMock, call, mock_open, patch
 
 from archey.entries.cpu import CPU
+from archey.test import CustomAssertions
 from archey.test.entries import HelperMethods
 from archey.constants import DEFAULT_CONFIG
 
 
-class TestCPUEntry(unittest.TestCase):
+class TestCPUEntry(unittest.TestCase, CustomAssertions):
     """
     Here, we mock the `open` call on `/proc/cpuinfo` with fake content.
     In some cases, `lscpu` output is being mocked too.
@@ -23,14 +23,15 @@ vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
 model\t\t: YY
 model name\t: CPU-MODEL-NAME
+physical id\t: 0
 """),
         create=True
     )
-    def test_model_name_match_cpuinfo(self):
+    def test_parse_proc_cpuinfo_one_entry(self):
         """Test `/proc/cpuinfo` parsing"""
-        self.assertDictEqual(
-            CPU().value,
-            {'CPU-MODEL-NAME': 1}
+        self.assertListEqual(
+            CPU._parse_proc_cpuinfo(),  # pylint: disable=protected-access
+            [{'CPU-MODEL-NAME': 1}]
         )
 
     @patch(
@@ -42,29 +43,32 @@ vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
 model\t\t: YY
 model name\t: CPU-MODEL-NAME
+physical id\t: 0
 
-processor\t: 0
+processor\t: 1
 vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
 model\t\t: YY
 model name\t: ANOTHER-CPU-MODEL
+physical id\t: 1
 
-processor\t: 0
+processor\t: 2
 vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
 model\t\t: YY
 model name\t: ANOTHER-CPU-MODEL
+physical id\t: 1
 """),
         create=True
     )
-    def test_multiple_cpus_from_proc_cpuinfo(self):
+    def test_parse_proc_cpuinfo_multiple_entries(self):
         """Test `/proc/cpuinfo` parsing"""
-        self.assertDictEqual(
-            CPU().value,
-            {
-                'CPU-MODEL-NAME': 1,
-                'ANOTHER-CPU-MODEL': 2
-            }
+        self.assertListEqual(
+            CPU._parse_proc_cpuinfo(),  # pylint: disable=protected-access
+            [
+                {'CPU-MODEL-NAME': 1},
+                {'ANOTHER-CPU-MODEL': 2}
+            ]
         )
 
     @patch(
@@ -75,37 +79,40 @@ processor\t: 0
 vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
 model\t\t: YY
+model name\t: CPU-MODEL-NAME
+physical id\t: 0
+
+processor\t: 1
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: CPU-MODEL-NAME
+physical id\t: 1
+
+processor\t: 2
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: CPU-MODEL-NAME
+physical id\t: 0
+
+processor\t: 3
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: CPU-MODEL-NAME
+physical id\t: 1
 """),
         create=True
     )
-    @patch(
-        'archey.entries.cpu.check_output',
-        return_value="""\
-Architecture:        x86_64
-CPU op-mode(s):      32-bit, 64-bit
-Byte Order:          Little Endian
-CPU(s):              4
-On-line CPU(s) list: 0-3
-Thread(s) per core:  X
-Core(s) per socket:  Y
-Socket(s):           1
-NUMA node(s):        1
-Vendor ID:           CPU-VENDOR-NAME
-CPU family:          Z
-Model:               \xde\xad\xbe\xef
-Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
-""")
-    def test_model_name_match_lscpu(self, _):
-        """
-        Test model name parsing from `lscpu` output.
-
-        See issue #29 (ARM architectures).
-        `/proc/cpuinfo` will not contain `model name` info.
-        `lscpu` output will be used instead.
-        """
-        self.assertDictEqual(
-            CPU().value,
-            {'CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO': 4}
+    def test_parse_proc_cpuinfo_one_cpu_dual_socket(self):
+        """Test `/proc/cpuinfo` parsing for same CPU model across two sockets"""
+        self.assertListEqual(
+            CPU._parse_proc_cpuinfo(),  # pylint: disable=protected-access
+            [
+                {'CPU-MODEL-NAME': 2},
+                {'CPU-MODEL-NAME': 2}
+            ]
         )
 
     @patch(
@@ -116,15 +123,48 @@ processor\t: 0
 vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
 model\t\t: YY
-model name\t: CPU  MODEL\t  NAME
+model name\t: CPU-MODEL-NAME
+physical id\t: 0
+
+processor\t: 1
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: ANOTHER-CPU-MODEL
+physical id\t: 0
+
+processor\t: 2
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: ANOTHER\tCPU   MODEL WITH STRANGE S P  A   C     E     S
+physical id\t: 1
+
+processor\t: 3
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: ANOTHER\tCPU   MODEL WITH STRANGE S P  A   C     E     S
+physical id\t: 1
 """),
         create=True
     )
-    def test_spaces_squeezing(self):
-        """Test name sanitizing, needed on some platforms"""
-        self.assertDictEqual(
-            CPU().value,
-            {'CPU MODEL NAME': 1}
+    def test_parse_proc_cpuinfo_multiple_inconsistent_entries(self):
+        """
+        Test `/proc/cpuinfo` parsing with multiple CPUs sharing same physical ids (unlikely).
+        Also check our model name normalizations applied on white characters.
+        """
+        self.assertListEqual(
+            CPU._parse_proc_cpuinfo(),  # pylint: disable=protected-access
+            [
+                {
+                    'CPU-MODEL-NAME': 1,
+                    'ANOTHER-CPU-MODEL': 1
+                },
+                {
+                    'ANOTHER CPU MODEL WITH STRANGE S P A C E S': 2
+                }
+            ]
         )
 
     @patch(
@@ -132,29 +172,103 @@ model name\t: CPU  MODEL\t  NAME
         side_effect=PermissionError(),
         create=True
     )
+    def test_parse_proc_cpuinfo_unreadable_file(self, _):
+        """Check behavior when `/proc/cpuinfo` could not be read from disk"""
+        self.assertListEmpty(CPU._parse_proc_cpuinfo())  # pylint: disable=protected-access
+
     @patch(
         'archey.entries.cpu.check_output',
-        return_value="""\
+        side_effect=[
+            """\
 Architecture:        x86_64
 CPU op-mode(s):      32-bit, 64-bit
 Byte Order:          Little Endian
 CPU(s):              4
 On-line CPU(s) list: 0-3
-Thread(s) per core:  X
-Core(s) per socket:  Y
+Thread(s) per core:  1
+Core(s) per socket:  4
 Socket(s):           1
 NUMA node(s):        1
 Vendor ID:           CPU-VENDOR-NAME
 CPU family:          Z
 Model:               \xde\xad\xbe\xef
-Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
-""")
-    def test_proc_cpuinfo_unreadable(self, _, __):
-        """Check Archey does not crash when `/proc/cpuinfo` is not readable"""
-        self.assertDictEqual(
-            CPU().value,
-            {'CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO': 4}
-        )
+Model name:          CPU-MODEL-NAME
+""",
+            """\
+Architecture:        x86_64
+CPU op-mode(s):      32-bit, 64-bit
+Byte Order:          Little Endian
+CPU(s):              2
+On-line CPU(s) list: 0-1
+Thread(s) per core:  1
+Core(s) per socket:  2
+Socket(s):           1
+NUMA node(s):        1
+Vendor ID:           CPU-VENDOR-NAME
+CPU family:          Z
+Model:               \xde\xad\xbe\xef
+Model name:          CPU-MODEL-NAME
+
+Architecture:        x86_64
+CPU op-mode(s):      32-bit, 64-bit
+Byte Order:          Little Endian
+CPU(s):              4
+On-line CPU(s) list: 0-3
+Thread(s) per core:  2
+Core(s) per socket:  2
+Socket(s):           1
+NUMA node(s):        1
+Vendor ID:           CPU-VENDOR-NAME
+CPU family:          Z
+Model:               \xde\xad\xbe\xef
+Model name:          ANOTHER-CPU-MODEL
+""",
+            """\
+Architecture:        x86_64
+CPU op-mode(s):      32-bit, 64-bit
+Byte Order:          Little Endian
+CPU(s):              16
+On-line CPU(s) list: 0-15
+Thread(s) per core:  2
+Core(s) per socket:  4
+Socket(s):           2
+NUMA node(s):        2
+Vendor ID:           CPU-VENDOR-NAME
+CPU family:          Z
+Model:               \xde\xad\xbe\xef
+Model name:          CPU-MODEL-NAME
+"""])
+    def test_parse_lscpu_output(self, _):
+        """
+        Test model name parsing from `lscpu` output.
+
+        See issue #29 (ARM architectures).
+        `/proc/cpuinfo` will not contain `model name` info.
+        `lscpu` output will be used instead.
+        """
+        with self.subTest('Simple unique CPU.'):
+            self.assertListEqual(
+                CPU._parse_lscpu_output(),  # pylint: disable=protected-access
+                [{'CPU-MODEL-NAME': 4}]
+            )
+
+        with self.subTest('Two CPUs, 1 socket.'):
+            self.assertListEqual(
+                CPU._parse_lscpu_output(),  # pylint: disable=protected-access
+                [
+                    {'CPU-MODEL-NAME': 2},
+                    {'ANOTHER-CPU-MODEL': 4}
+                ]
+            )
+
+        with self.subTest('1 CPU, 2 sockets.'):
+            self.assertListEqual(
+                CPU._parse_lscpu_output(),  # pylint: disable=protected-access
+                [
+                    {'CPU-MODEL-NAME': 8},
+                    {'CPU-MODEL-NAME': 8}
+                ]
+            )
 
     @HelperMethods.patch_clean_configuration
     def test_various_output_configuration(self):
@@ -162,15 +276,12 @@ Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
         cpu_instance_mock = HelperMethods.entry_mock(CPU)
         output_mock = MagicMock()
 
-        cpu_instance_mock.value = {
-            'CPU-MODEL-NAME': 1,
-            'ANOTHER-CPU-MODEL': 2
-        }
+        cpu_instance_mock.value = [
+            {'CPU-MODEL-NAME': 1},
+            {'ANOTHER-CPU-MODEL': 2}
+        ]
 
         with self.subTest('Single-line combined output.'):
-            if sys.version_info < (3, 6):
-                self.skipTest("Cannot test behavior on Python < 3.6, skipping.")
-
             CPU.output(cpu_instance_mock, output_mock)
             output_mock.append.assert_called_once_with(
                 'CPU',
@@ -180,9 +291,6 @@ Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
         output_mock.reset_mock()
 
         with self.subTest('Single-line combined output (no count).'):
-            if sys.version_info < (3, 6):
-                self.skipTest("Cannot test behavior on Python < 3.6, skipping.")
-
             cpu_instance_mock.options['show_count'] = False
 
             CPU.output(cpu_instance_mock, output_mock)

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -282,6 +282,8 @@ Model name:          CPU-MODEL-NAME
         ]
 
         with self.subTest('Single-line combined output.'):
+            cpu_instance_mock.options['one_line'] = True
+
             CPU.output(cpu_instance_mock, output_mock)
             output_mock.append.assert_called_once_with(
                 'CPU',
@@ -292,6 +294,7 @@ Model name:          CPU-MODEL-NAME
 
         with self.subTest('Single-line combined output (no count).'):
             cpu_instance_mock.options['show_count'] = False
+            cpu_instance_mock.options['one_line'] = True
 
             CPU.output(cpu_instance_mock, output_mock)
             output_mock.append.assert_called_once_with(

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -1,14 +1,17 @@
 """Test module for Archey's CPU detection module"""
 
 import unittest
-from unittest.mock import mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 from archey.entries.cpu import CPU
+from archey.test.entries import HelperMethods
+from archey.constants import DEFAULT_CONFIG
 
 
 class TestCPUEntry(unittest.TestCase):
     """
     Here, we mock the `open` call on `/proc/cpuinfo` with fake content.
+    In some cases, `lscpu` output is being mocked too.
     """
     @patch(
         'archey.entries.cpu.open',
@@ -24,7 +27,44 @@ model name\t: CPU-MODEL-NAME
     )
     def test_model_name_match_cpuinfo(self):
         """Test `/proc/cpuinfo` parsing"""
-        self.assertEqual(CPU().value, 'CPU-MODEL-NAME')
+        self.assertDictEqual(
+            CPU().value,
+            {'CPU-MODEL-NAME': 1}
+        )
+
+    @patch(
+        'archey.entries.cpu.open',
+        mock_open(
+            read_data="""\
+processor\t: 0
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: CPU-MODEL-NAME
+
+processor\t: 0
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: ANOTHER-CPU-MODEL
+
+processor\t: 0
+vendor_id\t: CPU-VENDOR-NAME
+cpu family\t: X
+model\t\t: YY
+model name\t: ANOTHER-CPU-MODEL
+"""),
+        create=True
+    )
+    def test_multiple_cpus_from_proc_cpuinfo(self):
+        """Test `/proc/cpuinfo` parsing"""
+        self.assertDictEqual(
+            CPU().value,
+            {
+                'CPU-MODEL-NAME': 1,
+                'ANOTHER-CPU-MODEL': 2
+            }
+        )
 
     @patch(
         'archey.entries.cpu.open',
@@ -62,7 +102,10 @@ Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
         `/proc/cpuinfo` will not contain `model name` info.
         `lscpu` output will be used instead.
         """
-        self.assertEqual(CPU().value, 'CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO')
+        self.assertDictEqual(
+            CPU().value,
+            {'CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO': 4}
+        )
 
     @patch(
         'archey.entries.cpu.open',
@@ -78,7 +121,10 @@ model name\t: CPU  MODEL\t  NAME
     )
     def test_spaces_squeezing(self):
         """Test name sanitizing, needed on some platforms"""
-        self.assertEqual(CPU().value, 'CPU MODEL NAME')
+        self.assertDictEqual(
+            CPU().value,
+            {'CPU MODEL NAME': 1}
+        )
 
     @patch(
         'archey.entries.cpu.open',
@@ -104,7 +150,72 @@ Model name:          CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO
 """)
     def test_proc_cpuinfo_unreadable(self, _, __):
         """Check Archey does not crash when `/proc/cpuinfo` is not readable"""
-        self.assertEqual(CPU().value, 'CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO')
+        self.assertDictEqual(
+            CPU().value,
+            {'CPU-MODEL-NAME-WITHOUT-PROC-CPUINFO': 4}
+        )
+
+    @HelperMethods.patch_clean_configuration
+    def test_various_output_configuration(self):
+        """Test (non-)detection when there is not any graphical candidate"""
+        cpu_instance_mock = HelperMethods.entry_mock(CPU)
+        output_mock = MagicMock()
+
+        cpu_instance_mock.value = {
+            'CPU-MODEL-NAME': 1,
+            'ANOTHER-CPU-MODEL': 2
+        }
+
+        with self.subTest('Single-line combined output.'):
+            CPU.output(cpu_instance_mock, output_mock)
+            output_mock.append.assert_called_once_with(
+                'CPU',
+                'CPU-MODEL-NAME, 2 x ANOTHER-CPU-MODEL'
+            )
+
+        output_mock.reset_mock()
+
+        with self.subTest('Single-line combined output (no count).'):
+            cpu_instance_mock.options['show_count'] = False
+
+            CPU.output(cpu_instance_mock, output_mock)
+            output_mock.append.assert_called_once_with(
+                'CPU',
+                'CPU-MODEL-NAME, ANOTHER-CPU-MODEL'
+            )
+
+        output_mock.reset_mock()
+
+        with self.subTest('Multi-lines output (with counts).'):
+            cpu_instance_mock.options['show_count'] = True
+            cpu_instance_mock.options['one_line'] = False
+
+            CPU.output(cpu_instance_mock, output_mock)
+            self.assertEqual(output_mock.append.call_count, 2)
+            output_mock.append.assert_has_calls(
+                [
+                    call(
+                        'CPU',
+                        'CPU-MODEL-NAME'
+                    ),
+                    call(
+                        'CPU',
+                        '2 x ANOTHER-CPU-MODEL'
+                    )
+                ],
+                any_order=True  # Since Python < 3.6 doesn't have definite `dict` ordering.
+            )
+
+        output_mock.reset_mock()
+
+        with self.subTest('No CPU detected output.'):
+            cpu_instance_mock.value = {}
+
+            CPU.output(cpu_instance_mock, output_mock)
+            output_mock.append.assert_called_once_with(
+                'CPU',
+                DEFAULT_CONFIG['default_strings']['not_detected']
+            )
 
 
 if __name__ == '__main__':

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -293,7 +293,7 @@ Model name:          CPU-MODEL-NAME
         output_mock.reset_mock()
 
         with self.subTest('Single-line combined output (no count).'):
-            cpu_instance_mock.options['show_count'] = False
+            cpu_instance_mock.options['show_cores'] = False
             cpu_instance_mock.options['one_line'] = True
 
             CPU.output(cpu_instance_mock, output_mock)
@@ -305,7 +305,7 @@ Model name:          CPU-MODEL-NAME
         output_mock.reset_mock()
 
         with self.subTest('Multi-lines output (with counts).'):
-            cpu_instance_mock.options['show_count'] = True
+            cpu_instance_mock.options['show_cores'] = True
             cpu_instance_mock.options['one_line'] = False
 
             CPU.output(cpu_instance_mock, output_mock)

--- a/archey/test/entries/test_archey_gpu.py
+++ b/archey/test/entries/test_archey_gpu.py
@@ -45,7 +45,6 @@ XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
             'max_count': 2
         })
 
-
         output_mock = MagicMock()
         gpu.output(output_mock)
 

--- a/config.json
+++ b/config.json
@@ -25,7 +25,11 @@
 			"sensors_chipsets": [],
 			"use_fahrenheit": false
 		},
-		{ "type": "CPU" },
+		{
+			"type": "CPU",
+			"one_line": true,
+			"show_count": true
+		},
 		{
 			"type": "GPU",
 			"one_line": true,

--- a/config.json
+++ b/config.json
@@ -28,7 +28,7 @@
 		{
 			"type": "CPU",
 			"one_line": false,
-			"show_count": true
+			"show_cores": true
 		},
 		{
 			"type": "GPU",

--- a/config.json
+++ b/config.json
@@ -27,12 +27,12 @@
 		},
 		{
 			"type": "CPU",
-			"one_line": true,
+			"one_line": false,
 			"show_count": true
 		},
 		{
 			"type": "GPU",
-			"one_line": true,
+			"one_line": false,
 			"max_count": 2
 		},
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->


## Description
<!--- Describe your changes in detail -->
This is an API-breaking change.
Now multiple CPUs should be supported, and number of cores per CPU will be shown by default.

> Below examples show output changes for a dual CPUs setup (respectively with `N` & `M` cores).

Text output change :

```diff
- CPU: A-CPU-MODEL-NAME_1
+ CPU: N x A-CPU-MODEL-NAME_1, M x A-CPU-MODEL-NAME_2
```

JSON API change :

```diff
- "CPU": "A-CPU-MODEL-NAME_1",
+ "CPU": [
+     {"A-CPU-MODEL-NAME_1": N},
+     {"A-CPU-MODEL-NAME_2": M}
+ ],
```

See also new `one_line` & `show_count` options available for `CPU` entry type.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
It appears Archey does not support multiple CPUs (only the first one would be displayed).
Additionally, adding the number of cores may be relevant.

See also <https://github.com/dylanaraps/neofetch/issues/1467> partially related.
(@Nalorokk's output suggestion has been kindly implemented there.)

## How has this been tested ?
<!--- Include details of your testing environment here -->
Locally and unit tests.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] \[IF BREAKING\] This pull request targets the `develop` branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
