### PR TITLE
[META] Drops support for Python 3.4 (EOL)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.4, 3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
       - uses: actions/checkout@v2
@@ -53,10 +53,9 @@ jobs:
           time ./dist/archey
           rm dist/archey
 
-      # Disabled against Python 3.4 (PyInstaller does not support it since 4.0).
       # Disabled against PyPy (see <https://stackoverflow.com/a/22245203>).
       - name: Standalone building (with PyInstaller)
-        if: ${{ matrix.python-version != '3.4' && matrix.python-version != 'pypy3' }}
+        if: ${{ matrix.python-version != 'pypy3' }}
         run: |
           pyinstaller \
             --distpath dist \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The answer is [here](https://blog.samuel.domains/archey4).
 
 > PyPy is supported and may replace CPython.
 
+> Looking for Python 3.4 support ? Please refer to the latest v4.9 release.
+
 ### Highly recommended packages
 
 |     Environments      |             Packages              |                       Reasons                        |            Notes             |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The answer is [here](https://blog.samuel.domains/archey4).
 
 ### Required packages
 
-* `python3`
+* `python3` (>= 3.5)
 * `python3-distro` (`python-distro` on Arch Linux)
 * `python3-netifaces` (`python-netifaces` on Arch Linux)
 * `procps` (`procps-ng` on Arch Linux)
@@ -73,8 +73,6 @@ Now, it's time to use your favorite package manager. Some examples :
 * Arch-based distributions : `pacman -U ./archey4-4.Y.Z-R-any.pkg.tar.xz`
 * Debian-based distributions : `apt install ./archey4_4.Y.Z-R_all.deb`
 * RPM-based distributions : `dnf install ./archey4-4.Y.Z-R.py??.noarch.rpm`
-
-**Note to Debian 8 (Jessie) users** : As [`python3-distro`](https://tracker.debian.org/pkg/python-distro) is not available in your repositories, **you should opt for an [installation from PyPI](#install-from-pypi).**
 
 Further information about packaging are available [here](https://github.com/HorlogeSkynet/archey4/wiki/Packaging).
 

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -57,10 +57,8 @@ class Configuration(metaclass=Singleton):
                 self.update_recursive(self._config, json.load(f_config))
         except FileNotFoundError:
             return
-        # For backward compatibility with Python versions prior to 3.5.0
-        #   we use `ValueError` instead of `json.JSONDecodeError`.
-        except ValueError as value_error:
-            print('Warning: {0} ({1})'.format(value_error, path), file=sys.stderr)
+        except json.JSONDecodeError as json_decode_error:
+            print('Warning: {0} ({1})'.format(json_decode_error, path), file=sys.stderr)
             return
 
         # If the user does not want any warning to appear : 2> /dev/null

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -1,7 +1,7 @@
 """Disk usage detection class"""
 
 import re
-from subprocess import DEVNULL, PIPE, Popen
+from subprocess import DEVNULL, PIPE, run
 from csv import reader as csv_reader
 
 from archey.colors import Colors
@@ -106,15 +106,15 @@ class Disk(Entry):
         Mount points are used as keys since they are always unique.
         """
         try:
-            df_output = Popen(
+            df_output = run(
                 ['df', '-P', '-k'],
                 env={'LANG': 'C'}, universal_newlines=True,
                 stdout=PIPE,
                 # On error, `df` may "hold" `EXIT_FAILURE` as exit status code.
                 # Thus, we purposely silence STDERR and ignore its returned status code.
                 # See #92 (related to flatpak/xdg-desktop-portal#512).
-                stderr=DEVNULL
-            ).stdout.read()
+                stderr=DEVNULL, check=False
+            ).stdout
         except FileNotFoundError:
             # `df` isn't available on this system.
             return {}

--- a/archey/entries/temperature.py
+++ b/archey/entries/temperature.py
@@ -63,9 +63,7 @@ class Temperature(Entry):
 
         try:
             sensors_data = json.loads(sensors_output)
-        # For backward compatibility with Python versions prior to 3.5.0
-        #   we use `ValueError` instead of `json.JSONDecodeError`.
-        except ValueError:
+        except json.JSONDecodeError:
             return
 
         # Iterates over the chip-sets outputs to filter interesting values.

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -24,9 +24,7 @@ cpu family\t: X
 model\t\t: YY
 model name\t: CPU-MODEL-NAME
 physical id\t: 0
-"""),
-        create=True
-    )
+"""))
     def test_parse_proc_cpuinfo_one_entry(self):
         """Test `/proc/cpuinfo` parsing"""
         self.assertListEqual(
@@ -58,9 +56,7 @@ cpu family\t: X
 model\t\t: YY
 model name\t: ANOTHER-CPU-MODEL
 physical id\t: 1
-"""),
-        create=True
-    )
+"""))
     def test_parse_proc_cpuinfo_multiple_entries(self):
         """Test `/proc/cpuinfo` parsing"""
         self.assertListEqual(
@@ -102,9 +98,7 @@ cpu family\t: X
 model\t\t: YY
 model name\t: CPU-MODEL-NAME
 physical id\t: 1
-"""),
-        create=True
-    )
+"""))
     def test_parse_proc_cpuinfo_one_cpu_dual_socket(self):
         """Test `/proc/cpuinfo` parsing for same CPU model across two sockets"""
         self.assertListEqual(
@@ -146,9 +140,7 @@ cpu family\t: X
 model\t\t: YY
 model name\t: ANOTHER\tCPU   MODEL WITH STRANGE S P  A   C     E     S
 physical id\t: 1
-"""),
-        create=True
-    )
+"""))
     def test_parse_proc_cpuinfo_multiple_inconsistent_entries(self):
         """
         Test `/proc/cpuinfo` parsing with multiple CPUs sharing same physical ids (unlikely).
@@ -169,8 +161,7 @@ physical id\t: 1
 
     @patch(
         'archey.entries.cpu.open',
-        side_effect=PermissionError(),
-        create=True
+        side_effect=PermissionError()
     )
     def test_parse_proc_cpuinfo_unreadable_file(self, _):
         """Check behavior when `/proc/cpuinfo` could not be read from disk"""

--- a/archey/test/entries/test_archey_disk.py
+++ b/archey/test/entries/test_archey_disk.py
@@ -128,11 +128,11 @@ class TestDiskEntry(unittest.TestCase):
             )
 
 
-    @patch('archey.entries.disk.Popen')
-    def test_disk_df_output_dict(self, popen_mock):
-        """Test method to get `df` output as a dict by mocking calls to `Popen`"""
+    @patch('archey.entries.disk.run')
+    def test_disk_df_output_dict(self, run_mock):
+        """Test method to get `df` output as a dict by mocking calls to `subprocess.run`"""
         with self.subTest('`df` regular output.'):
-            popen_mock.return_value.stdout.read.return_value = '\n'.join([
+            run_mock.return_value.stdout = '\n'.join([
                 "Filesystem               1024-blocks      Used     Available Capacity Mounted on",
                 "/dev/nvme0n1p2             499581952 427458276      67779164      87% /",
                 "tmpfs                        8127236       292       8126944       1% /tmp",
@@ -161,7 +161,7 @@ class TestDiskEntry(unittest.TestCase):
             )
 
         with self.subTest('`df` missing from system.'):
-            popen_mock.side_effect = FileNotFoundError()
+            run_mock.side_effect = FileNotFoundError()
             self.assertDictEqual(
                 Disk._get_df_output_dict(),  # pylint: disable=protected-access
                 {}

--- a/archey/test/entries/test_archey_hostname.py
+++ b/archey/test/entries/test_archey_hostname.py
@@ -13,17 +13,14 @@ class TestHostnameEntry(unittest.TestCase):
         mock_open(
             read_data="""\
 MY-COOL-LAPTOP
-"""),
-        create=True
-    )
+"""))
     def test_etc_hostname(self):
         """Mock reading from `/etc/hostname`"""
         self.assertEqual(Hostname().value, 'MY-COOL-LAPTOP')
 
     @patch(
         'archey.entries.hostname.open',
-        side_effect=FileNotFoundError(),
-        create=True
+        side_effect=FileNotFoundError()
     )
     @patch(
         'archey.entries.hostname.check_output',

--- a/archey/test/entries/test_archey_lan_ip.py
+++ b/archey/test/entries/test_archey_lan_ip.py
@@ -298,8 +298,7 @@ class TestLanIPEntry(unittest.TestCase, CustomAssertions):
     )
     @patch(
         'archey.entries.lan_ip.print',
-        return_value=None,  # Let's nastily mute class' outputs.
-        create=True
+        return_value=None  # Let's nastily mute class' outputs.
     )
     @HelperMethods.patch_clean_configuration
     def test_netifaces_not_available(self, _):

--- a/archey/test/entries/test_archey_model.py
+++ b/archey/test/entries/test_archey_model.py
@@ -119,7 +119,7 @@ class TestModelEntry(unittest.TestCase):
     def test_fetch_product_info(self):
         """Test `_fetch_product_info` static method"""
         # Product name and version available.
-        with patch('archey.entries.model.open', mock_open(), create=True) as mock:
+        with patch('archey.entries.model.open', mock_open()) as mock:
             mock.return_value.read.side_effect = [
                 'MY-LAPTOP-NAME\n',
                 'MY-LAPTOP-VERSION\n'
@@ -131,7 +131,7 @@ class TestModelEntry(unittest.TestCase):
             )
 
         # Only product name is available.
-        with patch('archey.entries.model.open', mock_open(), create=True) as mock:
+        with patch('archey.entries.model.open', mock_open()) as mock:
             mock.return_value.read.side_effect = [
                 'MY-LAPTOP-NAME\n',
                 FileNotFoundError()
@@ -143,7 +143,7 @@ class TestModelEntry(unittest.TestCase):
             )
 
         # Product name is available but product version is empty.
-        with patch('archey.entries.model.open', mock_open(), create=True) as mock:
+        with patch('archey.entries.model.open', mock_open()) as mock:
             mock.return_value.read.side_effect = [
                 'MY-LAPTOP-NAME\n',
                 '\n'
@@ -155,7 +155,7 @@ class TestModelEntry(unittest.TestCase):
             )
 
         # Neither product name nor version are available.
-        with patch('archey.entries.model.open', mock_open(), create=True) as mock:
+        with patch('archey.entries.model.open', mock_open()) as mock:
             mock.return_value.read.side_effect = [
                 FileNotFoundError(),
                 FileNotFoundError()
@@ -164,7 +164,7 @@ class TestModelEntry(unittest.TestCase):
             self.assertIsNone(Model._fetch_product_info())  # pylint: disable=protected-access
 
         # Product information are really weird...
-        with patch('archey.entries.model.open', mock_open(), create=True) as mock:
+        with patch('archey.entries.model.open', mock_open()) as mock:
             mock.return_value.read.side_effect = [
                 'To Be Filled By O.E.M.\n'  # Only `product_name` will be read.
             ]
@@ -173,7 +173,7 @@ class TestModelEntry(unittest.TestCase):
 
     def test_fetch_raspberry_pi_revision(self):
         """Test `_fetch_raspberry_pi_revision` static method"""
-        with patch('archey.entries.model.open', mock_open(), create=True) as mock:
+        with patch('archey.entries.model.open', mock_open()) as mock:
             mock.return_value.read.side_effect = [
                 'Hardware\t: HARDWARE\nRevision\t: REVISION\n',
                 'processor   : 0\ncpu family  : X\n'

--- a/archey/test/entries/test_archey_ram.py
+++ b/archey/test/entries/test_archey_ram.py
@@ -112,9 +112,7 @@ Shmem:            451056 kB
 Slab:             314100 kB
 SReclaimable:     200792 kB
 SUnreclaim:       113308 kB
-"""),  # Some lines have been ignored as they are useless for computations.
-        create=True
-    )
+"""))  # Some lines have been ignored as they are useless for computations.
     def test_proc_meminfo(self, _):
         """Test `/proc/meminfo` parsing (when `free` is not available)"""
         self.assertDictEqual(
@@ -132,8 +130,7 @@ SUnreclaim:       113308 kB
     )
     @patch(
         'archey.entries.ram.open',
-        side_effect=PermissionError(),
-        create=True
+        side_effect=PermissionError()
     )
     @HelperMethods.patch_clean_configuration
     def test_not_detected(self, _, __):

--- a/archey/test/entries/test_archey_uptime.py
+++ b/archey/test/entries/test_archey_uptime.py
@@ -15,10 +15,9 @@ class TestUptimeEntry(unittest.TestCase):
     @patch(
         'archey.entries.uptime.open',
         mock_open(
-            read_data='0.00 XXXX.XX\n'
-        ),
-        create=True
-    )
+            read_data="""\
+0.00 XXXX.XX
+"""))
     def test_warming_up(self):
         """Test when the device has just been started..."""
         uptime = Uptime()
@@ -43,10 +42,9 @@ class TestUptimeEntry(unittest.TestCase):
     @patch(
         'archey.entries.uptime.open',
         mock_open(
-            read_data='120.25 XXXX.XX\n'
-        ),
-        create=True
-    )
+            read_data="""\
+120.25 XXXX.XX
+"""))
     def test_minutes_only(self):
         """Test when only minutes should be displayed"""
         output_mock = MagicMock()
@@ -59,10 +57,9 @@ class TestUptimeEntry(unittest.TestCase):
     @patch(
         'archey.entries.uptime.open',
         mock_open(
-            read_data='7260.50 XXXX.XX\n'
-        ),
-        create=True
-    )
+            read_data="""\
+7260.50 XXXX.XX
+"""))
     def test_hours_and_minute(self):
         """Test when only hours AND minutes should be displayed"""
         output_mock = MagicMock()
@@ -75,10 +72,9 @@ class TestUptimeEntry(unittest.TestCase):
     @patch(
         'archey.entries.uptime.open',
         mock_open(
-            read_data='90120.75 XXXX.XX\n'
-        ),
-        create=True
-    )
+            read_data="""\
+90120.75 XXXX.XX
+"""))
     def test_day_and_hour_and_minutes(self):
         """Test when only days, hours AND minutes should be displayed"""
         output_mock = MagicMock()
@@ -91,10 +87,9 @@ class TestUptimeEntry(unittest.TestCase):
     @patch(
         'archey.entries.uptime.open',
         mock_open(
-            read_data='259381.99 XXXX.XX\n'
-        ),
-        create=True
-    )
+            read_data="""\
+259381.99 XXXX.XX
+"""))
     def test_days_and_minutes(self):
         """Test when only days AND minutes should be displayed"""
         uptime = Uptime()
@@ -118,17 +113,15 @@ class TestUptimeEntry(unittest.TestCase):
 
     @patch(
         'archey.entries.uptime.open',
-        side_effect=PermissionError(),
-        create=True
+        side_effect=PermissionError()
     )
     @patch(
         'archey.entries.uptime.time.CLOCK_BOOTTIME',  # Ensure first `getattr` call succeeds anyhow.
-        create=True
+        create=True                                   # Required for Python < 3.7.
     )
     @patch(
         'archey.entries.uptime.time.clock_gettime',
-        return_value=1000,
-        create=True
+        return_value=1000
     )
     def test_clock_fallback(self, _, __, ___):
         """
@@ -257,8 +250,7 @@ class TestUptimeEntry(unittest.TestCase):
 
     @patch(
         'archey.entries.uptime.open',
-        side_effect=PermissionError(),
-        create=True
+        side_effect=PermissionError()
     )
     @patch(
         'archey.entries.uptime.check_output',

--- a/archey/test/test_archey_output.py
+++ b/archey/test/test_archey_output.py
@@ -138,8 +138,7 @@ class TestOutputUtil(unittest.TestCase):
     )
     @patch(
         'archey.output.print',
-        return_value=None,  # Let's nastily mute class' outputs.
-        create=True
+        return_value=None  # Let's nastily mute class' outputs.
     )
     def test_centered_output(self, print_mock, _, __):
         """Test how the `output` method handles centering operations"""
@@ -293,8 +292,7 @@ FAKE_COLOR 22\x1b[0m\
     @patch('archey.output.get_terminal_size')
     @patch(
         'archey.output.print',
-        return_value=None,  # Let's nastily mute class' outputs.
-        create=True
+        return_value=None  # Let's nastily mute class' outputs.
     )
     def test_line_wrapping(self, print_mock, termsize_mock, _, __):
         """Test how the `output` method handles wrapping lines that are too long"""
@@ -352,8 +350,7 @@ O \x1b[0;31m\x1b[0m...\x1b[0m\
     )
     @patch(
         'archey.output.print',
-        return_value=None,  # Let's nastily mute class' outputs.
-        create=True
+        return_value=None  # Let's nastily mute class' outputs.
     )
     def test_format_to_json(self, print_mock, _, __):
         """Test how the `output` method handles JSON preferred formatting of entries"""

--- a/archey/test/test_archey_processes.py
+++ b/archey/test/test_archey_processes.py
@@ -53,8 +53,7 @@ there
     )
     @patch(
         'archey.processes.print',
-        return_value=None,  # Let's nastily mute class' outputs.
-        create=True
+        return_value=None  # Let's nastily mute class' outputs.
     )
     def test_ps_not_available(self, _, __):
         """Verifies that the program stops when `ps` is not available"""

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -92,7 +92,7 @@ fpm \
 	--output-type deb \
 	--package "${DIST_OUTPUT}/${NAME}_${VERSION}-${REVISION}_all.deb" \
 	--depends 'procps' \
-	--depends 'python3 >= 3.4' \
+	--depends 'python3 >= 3.5' \
 	--depends 'python3-distro' \
 	--depends 'python3-netifaces' \
 	--python-install-lib 'usr/lib/python3/dist-packages/' \

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='GPLv3',
     packages=find_packages(exclude=['archey.test*']),
     test_suite='archey.test',
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     install_requires=[
         'distro',
         'netifaces'
@@ -56,7 +56,6 @@ Remain *maintained*, *community-driven* and *highly-compatible* with yesterday's
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
Drop Python 3.4 support and removes code addressing particular old behaviors.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
Python 3.4 is EOL for a while now, and dropping it allows us to move forward.

## How has this been tested ?
<!--- Include details of your testing environment here -->
CI.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [X] \[IF BREAKING\] This pull request targets the `develop` branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
