### PR TITLE
use the float() method to avoid invalid literal for int() with base 10

### DIFF
--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -129,8 +129,8 @@ class Disk(Entry):
             columns = df_entry.split(maxsplit=5)
             df_output_dict[columns[5]] = {  # 6th column === mount point.
                 'device_path': columns[0],
-                'used_blocks': int(columns[2]),
-                'total_blocks': int(columns[1])
+                'used_blocks': int(float(columns[2])),
+                'total_blocks': int(float(columns[1]))
             }
 
         return df_output_dict


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

use the float() method to avoid invalid literal for int() with base 10

## Description
<!--- Describe your changes in detail -->

The Python ValueError: invalid literal for int() with base 10 error is raised when you try to convert a string value that is not formatted as an integer.

To solve this problem, you can use the float() method to convert a floating-point number in a string to an integer. Then, you can use int() to convert your number to an integer.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
Traceback (most recent call last):
  File "/opt/homebrew/bin/archey", line 33, in <module>
    sys.exit(load_entry_point('archey4==4.13.1', 'console_scripts', 'archey')())
  File "/opt/homebrew/Cellar/archey4/4.13.1/libexec/lib/python3.9/site-packages/archey/__main__.py", line 168, in main
    for entry_instance in mapper(_entry_instantiator, available_entries):
  File "/opt/homebrew/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 608, in result_iterator
    yield fs.pop().result()
  File "/opt/homebrew/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 438, in result
    return self.__get_result()
  File "/opt/homebrew/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 390, in __get_result
    raise self._exception
  File "/opt/homebrew/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/homebrew/Cellar/archey4/4.13.1/libexec/lib/python3.9/site-packages/archey/__main__.py", line 144, in _entry_instantiator
    return Entries[entry.pop('type')].value(
  File "/opt/homebrew/Cellar/archey4/4.13.1/libexec/lib/python3.9/site-packages/archey/entries/disk.py", line 18, in __init__
    self._disk_dict = self._get_df_output_dict()
  File "/opt/homebrew/Cellar/archey4/4.13.1/libexec/lib/python3.9/site-packages/archey/entries/disk.py", line 133, in _get_df_output_dict
    'total_blocks': int(columns[1])
ValueError: invalid literal for int() with base 10: 'Us.app/Wrapper'

## How has this been tested ?
<!--- Include details of your testing environment here -->
Python 3.9.7 on MacOS 11.6

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [ ] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [ ] \[IF BREAKING\] This pull request targets next Archey version branch ;
- [ X] My changes looks good ;
- [ X] I agree that my code may be modified in the future ;
- [ X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
