### PR TITLE
[OUTPUT] Allows entries color overriding from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ Below stand further descriptions for each available (default) option :
 	// If set to `true`, any execution warning or error would be hidden.
 	// Configuration parsing warnings **would** still be shown.
 	"suppress_warnings": false,
+	// Use this option to specify a custom color for entries (logo won't be affected).
+	// Value should be a string suitable for inclusion in the ANSI/ECMA-48 escape code for setting graphical rendition
+	//
+	// For instance "5;31;47" would result in yellow text blinking on white background.
+	// See <https://wiki.bash-hackers.org/scripting/terminalcodes> for more information.
+	"entries_color": "",
 	// Set this option to `false` to force Archey to use its own colors palettes.
 	// `true` by default to honor os-release(5) `ANSI_COLOR` option.
 	"honor_ansi_color": true,

--- a/archey/colors.py
+++ b/archey/colors.py
@@ -19,7 +19,8 @@ class Colors(Enum):
     ANSI terminal colors enumeration.
     Supports an arbitrary number of display attributes.
 
-    See <http://www.termsys.demon.co.uk/vtansi.htm#colors>.
+    See <https://web.archive.org/web/20200627145120/http://www.termsys.demon.co.uk/vtansi.htm>
+      or <https://en.wikipedia.org/wiki/ANSI_escape_code>.
     """
     CLEAR = (0,)
     RED_NORMAL = (0, 31)

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -15,6 +15,7 @@ DEFAULT_CONFIG = {
     'allow_overriding': True,
     'parallel_loading': True,
     'suppress_warnings': False,
+    'entries_color': '',
     'honor_ansi_color': True,
     'default_strings': {
         'latest': 'latest',

--- a/archey/output.py
+++ b/archey/output.py
@@ -49,11 +49,18 @@ class Output:
         else:
             self._logo, self._colors = logo_module.LOGO.copy(), logo_module.COLORS.copy()
 
+        configuration = Configuration()
+
         # If `os-release`'s `ANSI_COLOR` option is set, honor it.
         ansi_color = Distributions.get_ansi_color()
-        if ansi_color and Configuration().get('honor_ansi_color'):
+        if ansi_color and configuration.get("honor_ansi_color"):
             # Replace each Archey integrated colors by `ANSI_COLOR`.
             self._colors = len(self._colors) * [Colors.escape_code_from_attrs(ansi_color)]
+
+        entries_color = configuration.get("entries_color")
+        self._entries_color = (
+            Colors.escape_code_from_attrs(entries_color) if entries_color else self._colors[0]
+        )
 
         # Each entry will be added to this list
         self._entries = []
@@ -66,7 +73,7 @@ class Output:
 
     def append(self, key: str, value):
         """Append a pre-formatted entry to the final output content"""
-        self._results.append(f'{self._colors[0]}{key}:{Colors.CLEAR} {value}')
+        self._results.append(f"{self._entries_color}{key}:{Colors.CLEAR} {value}")
 
     def output(self):
         """

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
 	"allow_overriding": true,
 	"parallel_loading": true,
 	"suppress_warnings": false,
+	"entries_color": "",
 	"honor_ansi_color": true,
 	"entries": [
 		{ "type": "User" },


### PR DESCRIPTION
> See #109 for context.

## How has this been tested ?
<!--- Include details of your testing environment here -->
Locally and unit tests.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
