### PR TITLE
[CORE] Adds support for custom entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (partially) adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Custom entry
+
 ## [v4.13.4] - 2022-03-20
 ### Added
 - Support for `pacstall` package manager

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The answer is [here](https://blog.samuel.domains/archey4).
 * General temperature detection
 * JSON output
 * Screen capture ("best effort")
+* Custom entries
 
 ## Supported platforms
 
@@ -400,6 +401,24 @@ Below stand further descriptions for each available (default) option :
 				"http_url": "https://v6.ident.me/",
 				"http_timeout": 1
 			}
+		},
+		{
+			"type": "Custom",
+			// `command` option is mandatory. `shell` option defaults to `false`.
+			// Don't forget to set a `name` !
+			"name": "GPU",
+			// The custom shell command to execute.
+			"shell": true,
+			"command": "lshw -C display 2> /dev/null | rg product | cut -d ':' -f 2",
+			// A custom program and its arguments to execute.
+			"shell": false,
+			"command": ["echo", "My super GPU model !"],
+			// Whether or not command exit status code should be ignored (defaults to `true`).
+			"check": true,
+			// Whether or not STDERR should be silenced instead of logged (defaults to `true`).
+			"log_stderr": true,
+			// Set to `false` not to join all output content on the same line.
+			"one_line": true
 		}
 	],
 	"default_strings": {

--- a/archey/__main__.py
+++ b/archey/__main__.py
@@ -43,6 +43,7 @@ from archey.entries.ram import RAM as e_RAM
 from archey.entries.disk import Disk as e_Disk
 from archey.entries.lan_ip import LanIP as e_LanIP
 from archey.entries.wan_ip import WanIP as e_WanIP
+from archey.entries.custom import Custom as e_Custom
 
 
 class Entries(Enum):
@@ -71,6 +72,7 @@ class Entries(Enum):
     Disk = e_Disk
     LAN_IP = e_LanIP
     WAN_IP = e_WanIP
+    Custom = e_Custom
 
 
 def args_parsing() -> argparse.Namespace:
@@ -129,7 +131,11 @@ def main():
     available_entries = configuration.get('entries')
     if available_entries is None:
         # If none were specified, lazy-mimic a full-enabled entries list without any configuration.
-        available_entries = [{'type': entry_name} for entry_name in Entries.__members__]
+        available_entries = [
+            {"type": entry_name}
+            for entry_name in Entries.__members__
+            if entry_name != Entries.Custom
+        ]
 
     output = Output(
         preferred_logo_style=args.logo_style,

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -38,6 +38,9 @@ class Configuration(metaclass=Singleton):
         # Deep-copy `DEFAULT_CONFIG` so we have a local copy to safely mutate.
         self._config = deepcopy(DEFAULT_CONFIG)
 
+        # We will track successfully loaded configuration files stat info.
+        self._config_files_info = {}
+
         # If a `config_path` has been specified, (try to) load it directly.
         if config_path:
             self._load_configuration(config_path)
@@ -52,6 +55,10 @@ class Configuration(metaclass=Singleton):
         A binding method to imitate the `dict.get()` behavior.
         """
         return self._config.get(key, default)
+
+    def get_config_files_info(self) -> Dict[str, os.stat_result]:
+        """Return a copy of loaded files stat info data"""
+        return self._config_files_info.copy()
 
     def _load_configuration(self, path: str):
         """
@@ -70,6 +77,7 @@ class Configuration(metaclass=Singleton):
         try:
             with open(path, mode='rb') as f_config:
                 Utility.update_recursive(self._config, json.load(f_config))
+                self._config_files_info[path] = os.fstat(f_config.fileno())
         except FileNotFoundError:
             return
         except json.JSONDecodeError as json_decode_error:

--- a/archey/configuration.py
+++ b/archey/configuration.py
@@ -1,17 +1,17 @@
 """Archey configuration module"""
 
-from copy import deepcopy
-
 import json
 import logging
 import os
+from copy import deepcopy
+from typing import Any, Dict
 
 from archey.singleton import Singleton
 from archey.utility import Utility
 
 
 # Below are default required configuration keys which will be used.
-DEFAULT_CONFIG = {
+DEFAULT_CONFIG: Dict[str, Any] = {
     'allow_overriding': True,
     'parallel_loading': True,
     'suppress_warnings': False,

--- a/archey/entries/custom.py
+++ b/archey/entries/custom.py
@@ -1,0 +1,49 @@
+"""Custom entry class"""
+
+from contextlib import suppress
+from subprocess import CalledProcessError, DEVNULL, PIPE, run
+from typing import List
+
+from archey.entry import Entry
+
+
+class Custom(Entry):
+    """Custom entry gathering info based on configuration options"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        shell = self.options.get("shell", False)
+        if shell:
+            command: str = self.options["command"]
+        else:
+            command: List[str] = self.options["command"]
+
+        log_stderr = self.options.get("log_stderr", True)
+
+        with suppress(CalledProcessError):
+            proc = run(
+                command,
+                stdout=PIPE,
+                stderr=PIPE if log_stderr else DEVNULL,
+                shell=shell,
+                check=self.options.get("check", True),
+                universal_newlines=True,
+            )
+            if proc.stdout:
+                self.value = proc.stdout.rstrip().splitlines()
+
+            if log_stderr and proc.stderr:
+                self._logger.warning("%s", proc.stderr.rstrip())
+
+    def output(self, output):
+        if not self.value:
+            output.append(self.name, self._default_strings.get("not_detected"))
+            return
+
+        # Join the results only if `one_line` option is enabled.
+        if self.options.get("one_line", True):
+            output.append(self.name, ", ".join(self.value))
+        else:
+            for element in self.value:
+                output.append(self.name, element)

--- a/archey/test/entries/test_archey_custom.py
+++ b/archey/test/entries/test_archey_custom.py
@@ -1,0 +1,113 @@
+"""Test module for Archey custom entry module"""
+
+import unittest
+from unittest.mock import MagicMock, call
+
+from archey.configuration import DEFAULT_CONFIG
+from archey.entries.custom import Custom
+
+
+class TestCustomEntry(unittest.TestCase):
+    """Custom entry unit test cases"""
+
+    def test_program_execution(self) -> None:
+        """Check program execution behavior"""
+        custom = Custom(
+            options={
+                "command": ["echo", "my output"],
+            }
+        )
+        self.assertListEqual(custom.value, ["my output"])
+
+    def test_shell_command(self) -> None:
+        """Check shell command behavior"""
+        custom = Custom(
+            options={
+                "shell": True,
+                "command": "export TEST='my output'; echo \"$TEST\"",
+            }
+        )
+        self.assertListEqual(custom.value, ["my output"])
+
+    def test_error_shell_command(self) -> None:
+        """Check error shell command behavior"""
+        custom = Custom(
+            options={
+                "command": ["false"],
+            }
+        )
+        self.assertIsNone(custom.value, None)
+
+    def test_ignored_error_shell_command(self) -> None:
+        """Check ignored error shell command behavior"""
+        custom = Custom(
+            options={
+                "shell": True,
+                "command": "echo 'my output' && false",
+                "check": False,
+            }
+        )
+        self.assertListEqual(custom.value, ["my output"])
+
+    def test_silenced_shell_command(self) -> None:
+        """Check silenced shell command behavior"""
+        custom = Custom(
+            options={
+                "shell": True,
+                "command": "echo 'my output' > /dev/stderr",
+                "log_stderr": False,
+            }
+        )
+        self.assertIsNone(custom.value, None)
+
+    def test_multiple_lines_command_output(self) -> None:
+        """Check multiple lines command output"""
+        custom = Custom(
+            options={
+                "shell": True,
+                "command": "echo 'Model 1'; echo 'Model 2'",
+            }
+        )
+        self.assertListEqual(custom.value, ["Model 1", "Model 2"])
+
+        output_mock = MagicMock()
+
+        with self.subTest("Single-line combined output."):
+            custom.options["one_line"] = True
+
+            custom.output(output_mock)
+
+            output_mock.append.assert_called_once_with("Custom", "Model 1, Model 2")
+
+        output_mock.reset_mock()
+
+        with self.subTest("Multi-lines combined output."):
+            custom.options["one_line"] = False
+
+            custom.output(output_mock)
+
+            self.assertEqual(output_mock.append.call_count, 2)
+            output_mock.append.assert_has_calls(
+                [
+                    call("Custom", "Model 1"),
+                    call("Custom", "Model 2"),
+                ]
+            )
+
+        output_mock.reset_mock()
+
+        with self.subTest("No detected output."):
+            custom.value = []
+
+            custom.output(output_mock)
+
+            output_mock.append.assert_called_once_with(
+                "Custom",
+                DEFAULT_CONFIG["default_strings"]["not_detected"],
+            )
+
+        output_mock.reset_mock()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This patch brings a first support for "custom entries" to Archey. It
mainly allows users to run custom commands through their configuration
file.

In order to give "power to the user" for most of situations:
* STDERR output **MAY** be silenced through `log_stderr` option
* command exit status code **MAY** be ignored through `check` option

Multi-lines results will be joined on the same line, unless `one_line`
option is disabled.

Users **SHOULD** only enable `shell` option if they have to.

> See #111 for rationale.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
