### PR TITLE
Add support for FreeBSD

### DIFF
--- a/archey/entries/cpu.py
+++ b/archey/entries/cpu.py
@@ -47,7 +47,7 @@ class CPU(Entry):
         else:
             # Darwin or any other BSD-based system.
             self.value = self._parse_system_profiler() or \
-                self._parse_sysctl_machdep()
+                self._parse_sysctl_machdep() or self._parse_sysctl_cpu_model()
 
         if not self.value:
             # This test case has been built for some ARM architectures (see #29).
@@ -157,6 +157,24 @@ class CPU(Entry):
                 [
                     'sysctl', '-n',
                     'machdep.cpu.brand_string', 'machdep.cpu.core_count'
+                ],
+                stderr=DEVNULL, universal_newlines=True
+            )
+        except (FileNotFoundError, CalledProcessError):
+            return []
+
+        # `sysctl_output` should exactly contains two lines.
+        model_name, nb_cores = sysctl_output.splitlines()
+        return [{model_name: int(nb_cores)}]
+
+    @staticmethod
+    def _parse_sysctl_cpu_model() -> List[Dict[str, int]]:
+        # Runs `sysctl` to fetch some `hw.model and hw.ncpu` keys.
+        try:
+            sysctl_output = check_output(
+                [
+                    'sysctl', '-n',
+                    'hw.model', 'hw.ncpu'
                 ],
                 stderr=DEVNULL, universal_newlines=True
             )

--- a/archey/entries/cpu.py
+++ b/archey/entries/cpu.py
@@ -169,7 +169,7 @@ class CPU(Entry):
 
     @staticmethod
     def _parse_sysctl_cpu_model() -> List[Dict[str, int]]:
-        # Runs `sysctl` to fetch some `hw.model and hw.ncpu` keys.
+        # Runs `sysctl` to fetch `hw.model` and `hw.ncpu` keys.
         try:
             sysctl_output = check_output(
                 [

--- a/archey/entries/model.py
+++ b/archey/entries/model.py
@@ -23,7 +23,8 @@ class Model(Entry):
             or self._fetch_dmi_info() \
             or self._fetch_sysctl_hw() \
             or self._fetch_raspberry_pi_revision() \
-            or self._fetch_android_device_model()
+            or self._fetch_android_device_model() \
+            or self._fetch_freebsd_model()
 
     def _fetch_virtual_env_info(self) -> Optional[str]:
         """
@@ -179,3 +180,20 @@ class Model(Entry):
             return None
 
         return f'{brand} ({model})'
+
+    @staticmethod
+    def _fetch_freebsd_model() -> Optional[str]:
+        """Retrieve `vendor` and `version` properties on FreeBSD"""
+        try:
+            vendor = check_output(
+                ['kenv', 'smbios.bios.vendor'],
+                universal_newlines=True
+            ).rstrip()
+            product = check_output(
+                ['kenv', 'smbios.system.version'],
+                universal_newlines=True
+            ).rstrip()
+        except FileNotFoundError:
+            return None
+
+        return f'{vendor} ({product})'

--- a/archey/entries/model.py
+++ b/archey/entries/model.py
@@ -193,7 +193,7 @@ class Model(Entry):
                 ['kenv', 'smbios.system.version'],
                 universal_newlines=True
             ).rstrip()
-        except FileNotFoundError:
+        except (FileNotFoundError, CalledProcessError):
             return None
 
         return f'{vendor} ({product})'

--- a/archey/entries/ram.py
+++ b/archey/entries/ram.py
@@ -1,5 +1,6 @@
 """RAM usage detection class"""
 
+import os
 import platform
 import re
 
@@ -38,6 +39,9 @@ class RAM(Entry):
         if platform.system() == 'Linux':
             with suppress(IndexError, FileNotFoundError):
                 return self._run_free_dash_m()
+        elif platform.system() == 'FreeBSD':
+            with suppress(FileNotFoundError):
+                return self._run_sysctl_mem()
         else:
             # Darwin or any other BSD-based system.
             with suppress(FileNotFoundError):
@@ -122,6 +126,26 @@ class RAM(Entry):
         ) * page_size
 
         return (used / 1024**2), (total / 1024**2)
+
+    @staticmethod
+    def _run_sysctl_mem() -> Tuple[float, float]:
+        """
+        Return used and total memory on FreeBSD
+        """
+        output = check_output(
+                ['sysctl', '-n', 'vm.stats.vm.v_page_count',
+                                 'vm.stats.vm.v_free_count',
+                                 'vm.stats.vm.v_inactive_count'],
+                universal_newlines=True
+        )
+        total, free, inactive = [float(x) for x in output.splitlines()]
+
+        page_size = os.sysconf(os.sysconf_names['SC_PAGESIZE'])
+
+        mem_total = total * (page_size >> 10)
+        mem_used = (total - free - inactive) * (page_size >> 10)
+
+        return (mem_used / 1024), (mem_total / 1024)
 
 
     def output(self, output):

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -376,6 +376,24 @@ Model name:          CPU-MODEL-NAME
                 DEFAULT_CONFIG['default_strings']['not_detected']
             )
 
+    @patch(
+        'archey.entries.cpu.check_output',
+        side_effect=[
+            FileNotFoundError(),
+            """\
+Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz
+4
+"""])
+    def test_parse_sysctl_cpu_model(self, _):
+        """Check `_parse_sysctl_cpu_model` behavior"""
+        # pylint: disable=protected-access
+        self.assertListEmpty(CPU._parse_sysctl_cpu_model())
+        self.assertListEqual(
+            CPU._parse_sysctl_machdep(),
+            [{'Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz': 4}]
+        )
+        # pylint: enable=protected-access
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/archey/test/entries/test_archey_model.py
+++ b/archey/test/entries/test_archey_model.py
@@ -262,6 +262,24 @@ class TestModelEntry(unittest.TestCase):
             DEFAULT_CONFIG['default_strings']['not_detected']
         )
 
+    @patch(
+        'archey.entries.model.check_output',
+        side_effect=[
+            'VENDOR\n',     # First `kenv` call.
+            'VERSION\n',    # Second `kenv` call.
+            FileNotFoundError()  # Second test will fail.
+        ]
+    )
+    def test_fetch_freebsd_model(self, _):
+        """Test `_fetch_freebsd_model` static method"""
+        self.assertEqual(
+            Model._fetch_freebsd_model(),  # pylint: disable=protected-access
+            'VENDOR (VERSION)'
+        )
+        self.assertIsNone(
+            Model._fetch_freebsd_model()  # pylint: disable=protected-access
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/archey/test/entries/test_archey_ram.py
+++ b/archey/test/entries/test_archey_ram.py
@@ -100,6 +100,22 @@ Swapouts:                               3456015.
             (1685.58984375, 8192.0)
         )
 
+    @patch(
+        'archey.entries.ram.check_output',
+        side_effect=[
+            """\
+3992309
+3050620
+297854
+"""])
+    def test_run_sysctl_mem(self, _):
+        """Test _run_sysctl_mem() """
+        self.assertTupleEqual(
+            RAM._run_sysctl_mem(),  # pylint: disable=protected-access
+            (2514.98046875, 15594.95703125)
+        )
+
+
     @HelperMethods.patch_clean_configuration
     def test_various_output_configuration(self):
         """Test `output` overloading based on user preferences"""

--- a/archey/test/entries/test_archey_ram.py
+++ b/archey/test/entries/test_archey_ram.py
@@ -109,7 +109,7 @@ Swapouts:                               3456015.
 297854
 """])
     def test_run_sysctl_mem(self, _):
-        """Test _run_sysctl_mem() """
+        """Test _run_sysctl_mem()"""
         self.assertTupleEqual(
             RAM._run_sysctl_mem(),  # pylint: disable=protected-access
             (2514.98046875, 15594.95703125)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Hi,

I created a new port [sysutils/archey4](https://github.com/freebsd/freebsd-ports/commit/3be095c9e4fdb811ac3303d1b9a52487278e96ce) in our FreeBSD catalog ports tree. It contains all the patches I wrote to add support for the FreeBSD operating systems.

## Description
<!--- Describe your changes in detail -->
I added the 3 commits to solve the entries detection for the following:
- RAM memory
- CPU
- model

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
Missing entries not detected before these patches

## How has this been tested ?
<!--- Include details of your testing environment here -->
FreeBSD 14.0-CURRENT (development release) and FreeBSD 13.1-RELEASE (latest stable release)

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [x] Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [x] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- \[IF BREAKING\] This pull request targets next Archey version branch ;
- [x] My changes looks good ;
- [x] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
