### PR TITLE
[DISK] Fixes overcounting of APFS on macOS

### DIFF
--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -121,23 +121,24 @@ class Disk(Entry):
             return {}
 
         df_output_dict = {}
-        for df_entry_match in re.findall(
-            #  device_path
-            #          total_blocks
-            #                  used_blocks
-            #                                       mount point
-            r"^(.+?)\s+(\d+)\s+(\d+)\s+\d+\s+\d+%\s+(.*)$",
+        for df_entry_match in re.finditer(
+            r"""^(?P<device_path>.+?)\s+
+                 (?P<total_blocks>\d+)\s+
+                 (?P<used_blocks>\d+)\s+
+                 \d+\s+ # avail blocks
+                 \d+%\s+ # capacity
+                 (?P<mount_point>.*)$""",
             df_output,
-            flags=re.MULTILINE
+            flags=re.MULTILINE | re.VERBOSE
         ):
-            total_blocks = int(df_entry_match[1])
+            total_blocks = int(df_entry_match.group('total_blocks'))
             # Skip entries missing the number of blocks.
             if total_blocks == 0:
                 continue
 
-            df_output_dict[df_entry_match[3]] = {
-                'device_path': df_entry_match[0],
-                'used_blocks': int(df_entry_match[2]),
+            df_output_dict[df_entry_match.group('mount_point')] = {
+                'device_path': df_entry_match.group('device_path'),
+                'used_blocks': int(df_entry_match.group('used_blocks')),
                 'total_blocks': total_blocks
             }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replaces entries of APFS volumes with an aggregated entry for that volume's container.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
See #115.

## How has this been tested ?
<!--- Include details of your testing environment here -->
* [X] Unit tests
* [x] macOS runtime

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
