### PR TITLE
[CORE][FIX] Silences warning about broken `Custom` entry

### DIFF
--- a/archey/__main__.py
+++ b/archey/__main__.py
@@ -142,7 +142,7 @@ def main():
         available_entries = [
             {"type": entry_name}
             for entry_name in Entries.__members__
-            if entry_name != Entries.Custom
+            if entry_name != Entries.Custom.name
         ]
 
     output = Output(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
For users not using a configuration file, `available_entries` was built with a `Custom` entry lacking of required `command` field.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
See #120.

## How has this been tested ?
<!--- Include details of your testing environment here -->
On GNU/Linux.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
