### PR TITLE
[Output] Adds configuration option for preferred logo style

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ Below stand further descriptions for each available (default) option :
 	// Set this option to `false` to force Archey to use its own colors palettes.
 	// `true` by default to honor os-release(5) `ANSI_COLOR` option.
 	"honor_ansi_color": true,
+	// Set this option to an alternative logo style identifier instead of the default one for your distro.
+	// For example, "retro" would show the retro styled Apple logo on Darwin platforms.
+	// Note that the `--logo-style` argument overrides this setting.
+	"logo_style": "",
 	// Entries list.
 	// Add a `disabled` option set to `true` to temporary hide one.
 	// You may change entry displayed name by adding a `name` option.

--- a/archey/output.py
+++ b/archey/output.py
@@ -27,9 +27,15 @@ class Output:
     __LOGO_RIGHT_PADDING = "   "
 
     def __init__(self, **kwargs):
+        configuration = Configuration()
+
         # Fetches passed arguments.
         self._format_to_json = kwargs.get("format_to_json")
-        preferred_logo_style = (kwargs.get("preferred_logo_style") or "").upper()
+        preferred_logo_style = (
+            kwargs.get("preferred_logo_style")
+            or configuration.get("logo_style")
+            or ""
+        ).upper()
 
         try:
             # If set, force the distribution to `preferred_distribution` argument.
@@ -47,8 +53,6 @@ class Output:
             self._colors = getattr(logo_module, f"COLORS_{preferred_logo_style}").copy()
         else:
             self._logo, self._colors = logo_module.LOGO.copy(), logo_module.COLORS.copy()
-
-        configuration = Configuration()
 
         # If `os-release`'s `ANSI_COLOR` option is set, honor it.
         ansi_color = Distributions.get_ansi_color()

--- a/archey/test/test_archey_output.py
+++ b/archey/test/test_archey_output.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 from archey.colors import Colors
 from archey.distributions import Distributions
+from archey.logos import lazy_load_logo_module
 from archey.output import Output
 from archey.test.entries import HelperMethods
 
@@ -460,6 +461,32 @@ O    \x1b[0;31m\x1b[0m...\x1b[0m\
         )
         # Check `Distributions.get_local` method has not been called at all.
         self.assertFalse(get_local_mock.called)
+
+    @patch(
+        "archey.output.Distributions.get_local",
+        return_value=Distributions.DARWIN,  # Select Darwin.
+    )
+    @HelperMethods.patch_clean_configuration(configuration={"logo_style": ""})
+    def test_no_preferred_style(self, _):
+        """Test when no preferred logo style set in configuration"""
+        output = Output()
+        self.assertEqual(
+            output._logo,  # pylint: disable=protected-access
+            lazy_load_logo_module(Distributions.DARWIN.value).LOGO
+        )
+
+    @patch(
+        "archey.output.Distributions.get_local",
+        return_value=Distributions.DARWIN,  # Select Darwin.
+    )
+    @HelperMethods.patch_clean_configuration(configuration={"logo_style": "retro"})
+    def test_preferred_style(self, _):
+        """Test output logo matches preferred logo style specified in configuration"""
+        output = Output()
+        self.assertEqual(
+            output._logo,  # pylint: disable=protected-access
+            lazy_load_logo_module(Distributions.DARWIN.value).LOGO_RETRO
+        )
 
     @patch(
         "archey.output.Distributions.get_local",

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
 	"suppress_warnings": false,
 	"entries_color": "",
 	"honor_ansi_color": true,
+	"logo_style": "",
 	"entries": [
 		{ "type": "User" },
 		{ "type": "Hostname" },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Adds a configuration option for the preferred logo style

## Description
A few simple changes to `Output` to allow this.


## Reason and / or context
Feature addition by request :smiley:

## How has this been tested ?
Setting distribution to Darwin and specifying the option seems to work for me. Also worked when I added a placeholder extra logo for my own distro and specified it as a style.


## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [X] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [ ] \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
