### PR TITLE
correct spacing issue on univalent & moevalent logo

### DIFF
--- a/archey/logos/moevalent.py
+++ b/archey/logos/moevalent.py
@@ -17,6 +17,6 @@ LOGO = [
     """{c[0]}UUUUUUU       {c[1]}VVVVV       {c[0]}UUUUUUU""",
     """{c[0]}UUUUUUU        {c[1]}VVV        {c[0]}UUUUUUU""",
     """{c[0]}   UUUUUUU      {c[1]}V      {c[0]}UUUUUUU   """,
-    """{c[0]}      UUUUUUUUUUUUUUUUUUU        """,
-    """{c[0]}         UUUUUUUUUUUUU           """,
+    """{c[0]}       UUUUUUUUUUUUUUUUUUU       """,
+    """{c[0]}          UUUUUUUUUUUUU          """,
 ]

--- a/archey/logos/univalent.py
+++ b/archey/logos/univalent.py
@@ -17,6 +17,6 @@ LOGO = [
     """{c[0]}UUUUUUU       {c[1]}VVVVV       {c[0]}UUUUUUU""",
     """{c[0]}UUUUUUU        {c[1]}VVV        {c[0]}UUUUUUU""",
     """{c[0]}   UUUUUUU      {c[1]}V      {c[0]}UUUUUUU   """,
-    """{c[0]}      UUUUUUUUUUUUUUUUUUU        """,
-    """{c[0]}         UUUUUUUUUUUUU           """,
+    """{c[0]}       UUUUUUUUUUUUUUUUUUU       """,
+    """{c[0]}          UUUUUUUUUUUUU          """,
 ]


### PR DESCRIPTION
Corrected the blank positions on the bottom two lines of the Univalent and Moevalent logos. (Please forgive me to post continuously.)

## Description
The bottom two lines of the logos were shifted to the left by one half-pitch character, so I corrected it.

## Reason and / or context
The correct spacings were missing to properly align with the rest of the lines.

## How has this been tested ?
As usual, operation tests were conducted on both a virtual machine and a real one, but no problems were found.


## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [ ] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [ ] \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
