### PR TITLE
[WAN_IP] Fall back to HTTP properly on DNS connection errors

### DIFF
--- a/archey/entries/wan_ip.py
+++ b/archey/entries/wan_ip.py
@@ -46,17 +46,14 @@ class WanIP(Entry):
         dns_query = options.get("dns_query", "myip.opendns.com")
         if dns_query:
             # Run the DNS query.
-            try:
-                ip_address = self._run_dns_query(
-                    dns_query,
-                    options.get("dns_resolver", "resolver1.opendns.com"),
-                    ip_version,
-                    options.get("dns_timeout", 1),
-                )
-            except FileNotFoundError:
-                # DNS lookup tool does not seem to be available.
-                pass
-            else:
+            ip_address = self._run_dns_query(
+                dns_query,
+                options.get("dns_resolver", "resolver1.opendns.com"),
+                ip_version,
+                options.get("dns_timeout", 1),
+            )
+            # Return IP only if the query was successful
+            if ip_address is not None:
                 return ip_address
 
         # Is retrieval via HTTP(S) request enabled ?
@@ -84,7 +81,7 @@ class WanIP(Entry):
                 stderr=DEVNULL,
                 universal_newlines=True,
             ).rstrip()
-        except (TimeoutExpired, CalledProcessError):
+        except (FileNotFoundError, TimeoutExpired, CalledProcessError):
             return None
 
         # `ip_address` might be empty here.


### PR DESCRIPTION
## Description
This is just a small change so that if `dig` returns a nonzero exit code, then we don't immediately return `None` as the IP.

## Reason and / or context
For example on my home network I block outgoing port 53:
![image](https://github.com/HorlogeSkynet/archey4/assets/12384431/8e20fa0a-66fc-45db-a9a7-0d47c61a2717)
As you see in this case archey fails to get the IP with the default settings and doesn't fall back to the configured HTTP URL :frowning_face:

## How has this been tested ?
It now gets my IP and passes the additional test case I added

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Typo / style fix (non-breaking change which improves readability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] ~~\[IF NEEDED\] I have updated the _README.md_ file accordingly ;~~
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [ ] ~~\[IF BREAKING\] This pull request targets next Archey version branch ;~~
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
