### PR TITLE
[LOGO] Add Darwin retro low-intensity logo

### DIFF
--- a/archey/logos/darwin.py
+++ b/archey/logos/darwin.py
@@ -55,7 +55,7 @@ LOGO_RETRO = [
 # Alternative logo : Apple's "retro" logo (low intensity).
 
 COLORS_RETRO_LOW = [
-    Colors.CLEAR,
+    Colors.CYAN_NORMAL,
     Colors.GREEN_NORMAL,
     Colors.YELLOW_NORMAL,
     Colors.YELLOW_NORMAL,

--- a/archey/logos/darwin.py
+++ b/archey/logos/darwin.py
@@ -52,6 +52,20 @@ LOGO_RETRO = [
     """{c[0]}       {c[6]}####{c[0]}     {c[6]}#####{c[0]}    """,
 ]
 
+# Alternative logo : Apple's "retro" logo (low intensity).
+
+COLORS_RETRO_LOW = [
+    Colors.CLEAR,
+    Colors.GREEN_NORMAL,
+    Colors.YELLOW_NORMAL,
+    Colors.YELLOW_NORMAL,
+    Colors.RED_NORMAL,
+    Colors.MAGENTA_NORMAL,
+    Colors.BLUE_NORMAL,
+]
+
+LOGO_RETRO_LOW = LOGO_RETRO
+
 # Alternative logo: WWDC 2020 logo
 COLORS_WWDC20 = [
     Colors8Bit(1, 231),  # bright white


### PR DESCRIPTION
## Description
A copy of the Darwin `RETRO` logo with a different (non-bright) color set.

## Reason and / or context
`RETRO` looks broken on my terminal.
