### PR TITLE
[Output/Entry] Changes entries `output` method to `pretty_value` property

### DIFF
--- a/archey/colors.py
+++ b/archey/colors.py
@@ -99,7 +99,7 @@ class Colors8Bit(Style):
     """
 
     def __init__(self, bright: int, value: int):
-        if bright not in (0, 1) or value not in range(0, 255):
+        if bright not in (0, 1) or not 0 <= value <= 255:
             raise ValueError("Supplied color is outside the allowed range.")
         # `ESC[38;5` selects 8-bit foreground colour
         self.value = (bright, 38, 5, value)

--- a/archey/entries/cpu.py
+++ b/archey/entries/cpu.py
@@ -186,24 +186,11 @@ class CPU(Entry):
         model_name, nb_cores = sysctl_output.splitlines()
         return [{model_name: int(nb_cores)}]
 
-    @property
-    def pretty_value(self) -> Entry.ValueType:
-        """Provides CPU pretty value based on preferences"""
-        # No CPU could be detected.
-        if not self.value:
-            return [(self.name, self._default_strings.get("not_detected"))]
+    def __next__(self) -> Entry.ValueType:
+        """Yield nicely-formatted CPU values"""
+        cpu = next(self._iter_value)
 
-        entries = []
-        for cpus in self.value:
-            for model_name, cpu_count in cpus.items():
-                if cpu_count > 1 and self.options.get("show_cores", True):
-                    entries.append(f"{cpu_count} x {model_name}")
-                else:
-                    entries.append(model_name)
-
-        if self.options.get("one_line"):
-            # One-line output is enabled : Join the results !
-            return [(self.name, ", ".join(entries))]
-
-        # One-line output has been disabled, create one line per item.
-        return [(self.name, entry) for entry in entries]
+        model_name, cpu_count = next(iter(cpu.items()))  # This dict only ever has one entry
+        if cpu_count > 1 and self.options.get("show_cores", True):
+            return (self.name, f"{cpu_count} x {model_name}")
+        return (self.name, model_name)

--- a/archey/entries/cpu.py
+++ b/archey/entries/cpu.py
@@ -186,12 +186,12 @@ class CPU(Entry):
         model_name, nb_cores = sysctl_output.splitlines()
         return [{model_name: int(nb_cores)}]
 
-    def output(self, output) -> None:
-        """Writes CPUs to `output` based on preferences"""
+    @property
+    def pretty_value(self) -> Entry.ValueType:
+        """Provides CPU pretty value based on preferences"""
         # No CPU could be detected.
         if not self.value:
-            output.append(self.name, self._default_strings.get("not_detected"))
-            return
+            return [(self.name, self._default_strings.get("not_detected"))]
 
         entries = []
         for cpus in self.value:
@@ -203,8 +203,7 @@ class CPU(Entry):
 
         if self.options.get("one_line"):
             # One-line output is enabled : Join the results !
-            output.append(self.name, ", ".join(entries))
-        else:
-            # One-line output has been disabled, add one entry per item.
-            for entry in entries:
-                output.append(self.name, entry)
+            return [(self.name, ", ".join(entries))]
+
+        # One-line output has been disabled, create one line per item.
+        return [(self.name, entry) for entry in entries]

--- a/archey/entries/custom.py
+++ b/archey/entries/custom.py
@@ -63,13 +63,6 @@ class Custom(Entry):
             if log_stderr and proc.stderr:
                 self._logger.warning("%s", proc.stderr.rstrip())
 
-    @property
-    def pretty_value(self) -> Entry.ValueType:
-        if not self.value:
-            return [(self.name, self._default_strings.get("not_detected"))]
-
-        # Join the results only if `one_line` option is enabled.
-        if self.options.get("one_line", True):
-            return [(self.name, ", ".join(self.value))]
-
-        return [(self.name, element) for element in self.value]
+    def __next__(self) -> Entry.ValueType:
+        """Yield nicely-formatted entry values"""
+        return (self.name, str(next(self._iter_value)))

--- a/archey/entries/custom.py
+++ b/archey/entries/custom.py
@@ -63,14 +63,13 @@ class Custom(Entry):
             if log_stderr and proc.stderr:
                 self._logger.warning("%s", proc.stderr.rstrip())
 
-    def output(self, output) -> None:
+    @property
+    def pretty_value(self) -> Entry.ValueType:
         if not self.value:
-            output.append(self.name, self._default_strings.get("not_detected"))
-            return
+            return [(self.name, self._default_strings.get("not_detected"))]
 
         # Join the results only if `one_line` option is enabled.
         if self.options.get("one_line", True):
-            output.append(self.name, ", ".join(self.value))
-        else:
-            for element in self.value:
-                output.append(self.name, element)
+            return [(self.name, ", ".join(self.value))]
+
+        return [(self.name, element) for element in self.value]

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -4,10 +4,12 @@ import platform
 import plistlib
 import re
 from subprocess import DEVNULL, PIPE, check_output, run
-from typing import Dict, Iterable, List, Self
+from typing import Dict, Iterable, List, TypeVar
 
 from archey.colors import Colors
 from archey.entry import Entry
+
+Self = TypeVar("Self", bound="Disk")
 
 
 class Disk(Entry):
@@ -231,7 +233,7 @@ class Disk(Entry):
     def __str__(self):
         return "placeholder"
 
-    def __iter__(self) -> Self:
+    def __iter__(self: Self) -> Self:
         """Sets up iterable for entry."""
         # Combine all entries into one grand-total if configured to do so
         # (and we have a "truthy" value).

--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -228,9 +228,10 @@ class Disk(Entry):
 
         return f"{blocks:02.1f} {unit}{suffix}"
 
-    def output(self, output) -> None:
+    @property
+    def pretty_value(self) -> Entry.ValueType:
         """
-        Adds the entry to `output` after formatting with color and units.
+        Pretty-formats the entry with color and units.
         Follows the user configuration supplied for formatting.
         """
         # Fetch our `filesystems` object locally so we can modify it safely.
@@ -238,8 +239,7 @@ class Disk(Entry):
 
         if not filesystems:
             # We didn't find any disk, fall back to the default entry behavior.
-            super().output(output)
-            return
+            return super().pretty_value
 
         # DRY configuration object for the output.
         disk_labels = self.options.get("disk_labels")
@@ -272,6 +272,8 @@ class Disk(Entry):
                     name += " "
                 name += "({disk_label})"
 
+        entry_lines = []
+
         # We will only run this loop a single time for combined entries.
         for mount_point, filesystem_data in filesystems.items():
             # Select the corresponding level color based on disk percentage usage.
@@ -294,4 +296,6 @@ class Disk(Entry):
                 self._blocks_to_human_readable(filesystem_data["total_blocks"]),
             )
 
-            output.append(name.format(disk_label=disk_label), pretty_filesystem_value)
+            entry_lines.append((name.format(disk_label=disk_label), pretty_filesystem_value))
+
+        return entry_lines

--- a/archey/entries/distro.py
+++ b/archey/entries/distro.py
@@ -45,10 +45,7 @@ class Distro(Entry):
 
         return f"Darwin {platform.release()}"
 
-    def output(self, output) -> None:
-        output.append(
-            self.name,
-            f"{{}} {self.value['arch']}".format(
-                self.value["name"] or self._default_strings.get("not_detected")
-            ),
+    def __str__(self) -> str:
+        return f"{{}} {self.value['arch']}".format(
+            self.value["name"] or self._default_strings.get("not_detected")
         )

--- a/archey/entries/gpu.py
+++ b/archey/entries/gpu.py
@@ -84,15 +84,6 @@ class GPU(Entry):
 
         return gpus_list
 
-    @property
-    def pretty_value(self) -> Entry.ValueType:
-        """Pretty-formats GPUs based on preferences"""
-        # No GPU could be detected.
-        if not self.value:
-            return [(self.name, self._default_strings.get("not_detected"))]
-
-        # Join the results only if `one_line` option is enabled.
-        if self.options.get("one_line"):
-            return [(self.name, ", ".join(self.value))]
-
-        return [(self.name, gpu_device) for gpu_device in self.value]
+    def __next__(self) -> Entry.ValueType:
+        """Yield nicely-formatted GPU entry values"""
+        return (self.name, str(next(self._iter_value)))

--- a/archey/entries/gpu.py
+++ b/archey/entries/gpu.py
@@ -84,16 +84,15 @@ class GPU(Entry):
 
         return gpus_list
 
-    def output(self, output) -> None:
-        """Writes GPUs to `output` based on preferences"""
+    @property
+    def pretty_value(self) -> Entry.ValueType:
+        """Pretty-formats GPUs based on preferences"""
         # No GPU could be detected.
         if not self.value:
-            output.append(self.name, self._default_strings.get("not_detected"))
-            return
+            return [(self.name, self._default_strings.get("not_detected"))]
 
         # Join the results only if `one_line` option is enabled.
         if self.options.get("one_line"):
-            output.append(self.name, ", ".join(self.value))
-        else:
-            for gpu_device in self.value:
-                output.append(self.name, gpu_device)
+            return [(self.name, ", ".join(self.value))]
+
+        return [(self.name, gpu_device) for gpu_device in self.value]

--- a/archey/entries/kernel.py
+++ b/archey/entries/kernel.py
@@ -58,7 +58,7 @@ class Kernel(Entry):
 
         return kernel_releases.get("latest_stable", {}).get("version")
 
-    def output(self, output) -> None:
+    def __str__(self) -> "str":
         """Display running kernel and latest kernel if possible"""
         text_output = " ".join((self.value["name"], self.value["release"]))
 
@@ -68,4 +68,4 @@ class Kernel(Entry):
             else:
                 text_output += f" ({self._default_strings.get('latest')})"
 
-        output.append(self.name, text_output)
+        return text_output

--- a/archey/entries/lan_ip.py
+++ b/archey/entries/lan_ip.py
@@ -75,17 +75,15 @@ class LanIP(Entry):
                         # Finally, yield the address compressed representation.
                         yield ip_addr.compressed
 
-    def output(self, output) -> None:
-        """Adds the entry to `output` after pretty-formatting the IP address list."""
+    @property
+    def pretty_value(self) -> Entry.ValueType:
+        """Pretty-formats the IP address list."""
         # If we found IP addresses, join them together nicely.
         # If not, fall back on default strings according to `netifaces` availability.
         if self.value:
             if not self.options.get("one_line", True):
-                # One-line output has been disabled, add one IP address per item.
-                for ip_address in self.value:
-                    output.append(self.name, ip_address)
-
-                return
+                # One-line output has been disabled, create one line for each IP address.
+                return [(self.name, ip_address) for ip_address in self.value]
 
             text_output = ", ".join(self.value)
 
@@ -94,4 +92,4 @@ class LanIP(Entry):
         else:
             text_output = self._default_strings.get("not_detected")
 
-        output.append(self.name, text_output)
+        return [(self.name, text_output)]

--- a/archey/entries/lan_ip.py
+++ b/archey/entries/lan_ip.py
@@ -2,7 +2,7 @@
 
 import ipaddress
 from itertools import islice
-from typing import Iterator, Self
+from typing import Iterator, TypeVar
 
 try:
     import netifaces
@@ -10,6 +10,8 @@ except ImportError:
     netifaces = None
 
 from archey.entry import Entry
+
+Self = TypeVar("Self", bound="LanIP")
 
 
 class LanIP(Entry):
@@ -75,7 +77,7 @@ class LanIP(Entry):
                         # Finally, yield the address compressed representation.
                         yield ip_addr.compressed
 
-    def __iter__(self) -> Self:
+    def __iter__(self: Self) -> Self:
         """Sets up iterable over IP addresses"""
         if not self.value and netifaces:
             # If no IP addresses found, fall-back on the "No address" string.

--- a/archey/entries/load_average.py
+++ b/archey/entries/load_average.py
@@ -19,25 +19,17 @@ class LoadAverage(Entry):
         with suppress(AttributeError):
             self.value = os.getloadavg()
 
-    def output(self, output) -> None:
-        if not self.value:
-            # Fall back on the default behavior if load average values could not be detected.
-            super().output(output)
-            return
-
+    def __str__(self) -> str:
         # DRY constant thresholds.
         decimal_places = self.options.get("decimal_places", 2)
         warning_threshold = self.options.get("warning_threshold", 1.0)
         danger_threshold = self.options.get("danger_threshold", 2.0)
 
-        output.append(
-            self.name,
-            " ".join(
-                [
-                    str(Colors.get_level_color(load_avg, warning_threshold, danger_threshold))
-                    + str(round(load_avg, decimal_places))
-                    + str(Colors.CLEAR)
-                    for load_avg in self.value
-                ]
-            ),
+        return " ".join(
+            [
+                str(Colors.get_level_color(load_avg, warning_threshold, danger_threshold))
+                + str(round(load_avg, decimal_places))
+                + str(Colors.CLEAR)
+                for load_avg in self.value
+            ]
         )

--- a/archey/entries/ram.py
+++ b/archey/entries/ram.py
@@ -154,15 +154,7 @@ class RAM(Entry):
 
         return (mem_used / 1024), (mem_total / 1024)
 
-    def output(self, output) -> None:
-        """
-        Adds the entry to `output` after pretty-formatting the RAM usage with color and units.
-        """
-        if not self.value:
-            # Fall back on the default behavior if no RAM usage could be detected.
-            super().output(output)
-            return
-
+    def __str__(self) -> str:
         # DRY some constants
         used = self.value["used"]
         total = self.value["total"]
@@ -175,6 +167,4 @@ class RAM(Entry):
             self.options.get("danger_use_percent", 66.7),
         )
 
-        output.append(
-            self.name, f"{level_color}{int(used)} {unit}{Colors.CLEAR} / {int(total)} {unit}"
-        )
+        return f"{level_color}{int(used)} {unit}{Colors.CLEAR} / {int(total)} {unit}"

--- a/archey/entries/temperature.py
+++ b/archey/entries/temperature.py
@@ -226,13 +226,7 @@ class Temperature(Entry):
         """Simple Celsius to Fahrenheit conversion method"""
         return temp * (9 / 5) + 32
 
-    def output(self, output) -> None:
-        """Adds the entry to `output` after pretty-formatting with units."""
-        if not self.value:
-            # Fall back on the default behavior if no temperatures were detected.
-            super().output(output)
-            return
-
+    def __str__(self) -> str:
         # DRY some constants
         char_before_unit = self.value["char_before_unit"]
         unit = self.value["unit"]
@@ -242,4 +236,4 @@ class Temperature(Entry):
         if len(self._temps) > 1:
             entry_text += f" (Max. {self.value['max_temperature']}{char_before_unit}{unit})"
 
-        output.append(self.name, entry_text)
+        return entry_text

--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -121,10 +121,7 @@ class Terminal(Entry):
         # Note : It _might_ be `None` in very specific environments.
         return env_term
 
-    def output(self, output) -> None:
-        """Adds the entry to `output` after pretty-formatting with colors palette"""
-        text_output = self.value or self._default_strings.get("not_detected")
-        if Style.should_color_output():
-            text_output += " " + self._get_colors_palette()
-
-        output.append(self.name, text_output)
+    def __str__(self) -> str:
+        return self.value + (
+            " " + self._get_colors_palette() if Style.should_color_output() else ""
+        )

--- a/archey/entries/terminal.py
+++ b/archey/entries/terminal.py
@@ -122,6 +122,7 @@ class Terminal(Entry):
         return env_term
 
     def __str__(self) -> str:
-        return self.value + (
-            " " + self._get_colors_palette() if Style.should_color_output() else ""
-        )
+        text_output = self.value or self._default_strings.get("not_detected")
+        if Style.should_color_output():
+            text_output += " " + self._get_colors_palette()
+        return text_output

--- a/archey/entries/uptime.py
+++ b/archey/entries/uptime.py
@@ -147,8 +147,7 @@ class Uptime(Entry):
             seconds=int(uptime_args.get("seconds") or 0),
         )
 
-    def output(self, output) -> None:
-        """Adds the entry to `output` after pretty-formatting the uptime to a string."""
+    def __str__(self) -> str:
         days = self.value["days"]
         hours = self.value["hours"]
         minutes = self.value["minutes"]
@@ -180,4 +179,4 @@ class Uptime(Entry):
         elif not days and not hours:
             uptime = "< 1 minute"
 
-        output.append(self.name, uptime)
+        return uptime

--- a/archey/entries/wan_ip.py
+++ b/archey/entries/wan_ip.py
@@ -97,17 +97,15 @@ class WanIP(Entry):
         except (URLError, SocketTimeoutError):
             return None
 
-    def output(self, output) -> None:
-        """Adds the entry to `output` after pretty-formatting our list of IP addresses."""
+    @property
+    def pretty_value(self) -> Entry.ValueType:
+        """Pretty-formats our list of IP addresses."""
         # If we found IP addresses, join them together nicely.
         # If not, fall-back on the "No address" string.
         if self.value:
             if not self.options.get("one_line", True):
-                # One-line output has been disabled, add one IP address per item.
-                for ip_address in self.value:
-                    output.append(self.name, ip_address)
-
-                return
+                # One-line output has been disabled, create one line for each IP address.
+                return [(self.name, ip_address) for ip_address in self.value]
 
             text_output = ", ".join(self.value)
 
@@ -116,4 +114,4 @@ class WanIP(Entry):
         else:
             text_output = self._default_strings.get("not_detected")
 
-        output.append(self.name, text_output)
+        return [(self.name, text_output)]

--- a/archey/entries/wan_ip.py
+++ b/archey/entries/wan_ip.py
@@ -2,12 +2,14 @@
 
 from socket import timeout as SocketTimeoutError
 from subprocess import DEVNULL, CalledProcessError, TimeoutExpired, check_output
-from typing import Optional, Self
+from typing import Optional, TypeVar
 from urllib.error import URLError
 from urllib.request import urlopen
 
 from archey.entry import Entry
 from archey.environment import Environment
+
+Self = TypeVar("Self", bound="WanIP")
 
 
 class WanIP(Entry):
@@ -97,7 +99,7 @@ class WanIP(Entry):
         except (URLError, SocketTimeoutError):
             return None
 
-    def __iter__(self) -> Self:
+    def __iter__(self: Self) -> Self:
         """Sets up iterable over IP addresses"""
         if not self.value and not Environment.DO_NOT_TRACK:
             # If no IP addresses found, fall-back on the "No address" string.

--- a/archey/entries/window_manager.py
+++ b/archey/entries/window_manager.py
@@ -89,14 +89,13 @@ class WindowManager(Entry):
             "display_server_protocol": display_server_protocol,
         }
 
-    def output(self, output) -> None:
+    def __str__(self) -> str:
         # No WM could be detected.
         if self.value["name"] is None:
-            output.append(self.name, self._default_strings.get("not_detected"))
-            return
+            return self._default_strings.get("not_detected")
 
         text_output = self.value["name"]
         if self.value["display_server_protocol"] is not None:
             text_output += f" ({self.value['display_server_protocol']})"
 
-        output.append(self.name, text_output)
+        return text_output

--- a/archey/entry.py
+++ b/archey/entry.py
@@ -51,20 +51,16 @@ class Entry(AbstractBaseClass):
 
     def __iter__(self) -> Self:
         """Best-effort set up of an iterable of value for inherited entries to use."""
-        try:
-            if isinstance(self.value, str):
-                raise TypeError
-            if isinstance(self.value, dict):
-                self._iter_value = iter(self.value.items())
-            else:
-                self._iter_value = iter(self.value)
-        except TypeError:
-            # e.g. int, str, None
-            if self.value:
-                self._iter_value = iter([self.value])
-            else:
-                # Make an empty iterable rather than `[None]`
-                self._iter_value = iter([])
+        if isinstance(self.value, (str, int)):
+            self._iter_value = iter([self.value])
+        elif isinstance(self.value, dict):
+            self._iter_value = iter(self.value.items())
+        elif self.value:
+            # Don't know what it is -- let `iter` deal with it.
+            self._iter_value = iter(self.value)
+        else:
+            # Make an empty iterable rather than `[None]`
+            self._iter_value = iter([])
         return self
 
     def __next__(self) -> ValueType:
@@ -78,8 +74,8 @@ class Entry(AbstractBaseClass):
         # If the value is "truthy" use `__str__`
         if self.value:
             return (self.name, str(self))
-        # Otherwise, `None`
-        return (self.name, None)
+        # Otherwise, just raise `StopIteration` immediately
+        raise StopIteration
 
     def __str__(self) -> str:
         """Provide a sane default printable string representation of the entry"""

--- a/archey/entry.py
+++ b/archey/entry.py
@@ -3,7 +3,7 @@
 import logging
 from abc import ABC as AbstractBaseClass
 from abc import abstractmethod
-from typing import Optional
+from typing import List, Optional, TypeAlias
 
 from archey.configuration import Configuration
 
@@ -11,6 +11,7 @@ from archey.configuration import Configuration
 class Entry(AbstractBaseClass):
     """Module base class"""
 
+    ValueType: TypeAlias = List["tuple[str, str]"]
     _ICON: Optional[str] = None
     _PRETTY_NAME: Optional[str] = None
 
@@ -44,12 +45,20 @@ class Entry(AbstractBaseClass):
         # Provision a logger for each entry.
         self._logger = logging.getLogger(self.__module__)
 
-    def output(self, output) -> None:
-        """Output the results to output. Can be overridden by subclasses."""
+    def __str__(self) -> str:
+        """Provide a sane default printable string representation of the entry"""
+        # Assume that the `__str__` of our value is usable
+        return str(self.value)
+
+    @property
+    def pretty_value(self) -> ValueType:
+        """
+        Provide a "pretty" value. Can be overridden by subclasses.
+        Return value is a list (1 object per line) of tuples of (name, value).
+        """
         if self.value:
-            # Let's assume we can just use `__str__` on the object in value,
+            # Let's assume we can just use `__str__` on ourself,
             # and create a single-line output with it.
-            output.append(self.name, str(self.value))
-        else:
-            # If the value is "falsy" leave a generic "Not detected" message for this entry.
-            output.append(self.name, self._default_strings.get("not_detected"))
+            return [(self.name, str(self))]
+        # If the value is "falsy" leave a generic "Not detected" message for this entry.
+        return [(self.name, self._default_strings.get("not_detected"))]

--- a/archey/entry.py
+++ b/archey/entry.py
@@ -3,15 +3,17 @@
 import logging
 from abc import ABC as AbstractBaseClass
 from abc import abstractmethod
-from typing import Any, Iterator, Optional, Self, TypeAlias
+from typing import Any, Iterator, Optional, Tuple, TypeVar
 
 from archey.configuration import Configuration
+
+Self = TypeVar("Self", bound="Entry")
 
 
 class Entry(AbstractBaseClass):
     """Module base class"""
 
-    ValueType: TypeAlias = tuple[str, Optional[str]]
+    ValueType = Tuple[str, Optional[str]]
     _ICON: Optional[str] = None
     _PRETTY_NAME: Optional[str] = None
 
@@ -23,7 +25,9 @@ class Entry(AbstractBaseClass):
         return super().__new__(cls)
 
     @abstractmethod
-    def __init__(self, name: Optional[str] = None, value=None, options: Optional[dict] = None):
+    def __init__(
+        self: Self, name: Optional[str] = None, value=None, options: Optional[dict] = None
+    ):
         configuration = Configuration()
 
         # Each entry will have always have the following attributes...
@@ -49,7 +53,7 @@ class Entry(AbstractBaseClass):
         self._iter_idx = 0
         self._iter_value: Iterator[Any] = iter([])
 
-    def __iter__(self) -> Self:
+    def __iter__(self: Self) -> Self:
         """Best-effort set up of an iterable of value for inherited entries to use."""
         if isinstance(self.value, (str, int)):
             self._iter_value = iter([self.value])
@@ -63,7 +67,7 @@ class Entry(AbstractBaseClass):
             self._iter_value = iter([])
         return self
 
-    def __next__(self) -> ValueType:
+    def __next__(self: Self) -> ValueType:
         """
         Default behaviour: assume we can just use `__str__` on ourself for a single-line output.
         """
@@ -77,7 +81,7 @@ class Entry(AbstractBaseClass):
         # Otherwise, just raise `StopIteration` immediately
         raise StopIteration
 
-    def __str__(self) -> str:
+    def __str__(self: Self) -> str:
         """Provide a sane default printable string representation of the entry"""
         # Assume that the `__str__` of our value is usable
         return str(self.value)

--- a/archey/output.py
+++ b/archey/output.py
@@ -82,13 +82,27 @@ class Output:
         We either hand-off to JSON output, or get entries' pretty-formatted values and add them
         to the results.
         """
+        # DRY configuration access
+        configuration = Configuration()
         if self._format_to_json:
             self._output_json()
         else:
-            # Iterate through the entries and get their content.
+            # Iterate through the entries
             for entry in self._entries:
-                for entry_line in entry.pretty_value:
-                    self.append(*entry_line)
+                # Append single-line or multi-line content as appropriate
+                if entry.options.get("one_line", True):
+                    self.append(
+                        entry.name,
+                        ", ".join(entry_line[1] for entry_line in entry)
+                        or configuration.get("default_strings").get("not_detected"),
+                    )
+                else:
+                    for entry_line in entry:
+                        self.append(
+                            entry_line[0],
+                            entry_line[1]
+                            or configuration.get("default_strings").get("not_detected"),
+                        )
             self._output_text()
 
     def _output_json(self) -> None:

--- a/archey/output.py
+++ b/archey/output.py
@@ -79,15 +79,16 @@ class Output:
     def output(self) -> None:
         """
         Main `Output`'s `output` method.
-        First we get entries to add their outputs to the results and then
-        calls specific `output` methods based (for instance) on preferred format.
+        We either hand-off to JSON output, or get entries' pretty-formatted values and add them
+        to the results.
         """
         if self._format_to_json:
             self._output_json()
         else:
-            # Iterate through the entries and run their output method to add their content.
+            # Iterate through the entries and get their content.
             for entry in self._entries:
-                entry.output(self)
+                for entry_line in entry.pretty_value:
+                    self.append(*entry_line)
             self._output_text()
 
     def _output_json(self) -> None:

--- a/archey/test/entries/__init__.py
+++ b/archey/test/entries/__init__.py
@@ -37,9 +37,11 @@ class HelperMethods:
         # These instance-attributes are quite important, so let's mimic them.
         instance_mock.name = getattr(entry, "_PRETTY_NAME") or str(entry.__name__)
         instance_mock.value = None  # (entry default)
-        # Let's also configure the `__str__` magic method
+        # Let's also configure the magic methods
         # (MyPy doesn't realise this is a mock, see https://github.com/python/mypy/issues/2427)
         instance_mock.__str__ = entry.__str__  # type: ignore
+        instance_mock.__iter__ = entry.__iter__  # type: ignore
+        instance_mock.__next__ = entry.__next__  # type: ignore
         # We don't have default entry options defined outside of entries.
         instance_mock.options = options or {}
 

--- a/archey/test/entries/__init__.py
+++ b/archey/test/entries/__init__.py
@@ -37,6 +37,9 @@ class HelperMethods:
         # These instance-attributes are quite important, so let's mimic them.
         instance_mock.name = getattr(entry, "_PRETTY_NAME") or str(entry.__name__)
         instance_mock.value = None  # (entry default)
+        # Let's also configure the `__str__` magic method
+        # (MyPy doesn't realise this is a mock, see https://github.com/python/mypy/issues/2427)
+        instance_mock.__str__ = entry.__str__  # type: ignore
         # We don't have default entry options defined outside of entries.
         instance_mock.options = options or {}
 

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -3,7 +3,6 @@
 import unittest
 from unittest.mock import mock_open, patch
 
-from archey.configuration import DEFAULT_CONFIG
 from archey.entries.cpu import CPU
 from archey.test import CustomAssertions
 from archey.test.entries import HelperMethods
@@ -329,39 +328,33 @@ Cluster(s): 1
 
     @HelperMethods.patch_clean_configuration
     def test_various_output_configuration(self):
-        """Test `pretty_value` output overloading based on user preferences combination"""
+        """
+        Test `__iter__` and `__next__` output overloading based on user preferences combination
+        """
         cpu_instance_mock = HelperMethods.entry_mock(CPU)
 
         cpu_instance_mock.value = [{"CPU-MODEL-NAME": 1}, {"ANOTHER-CPU-MODEL": 2}]
 
-        with self.subTest("Single-line combined output."):
+        with self.subTest("Normal output."):
             cpu_instance_mock.options["one_line"] = True
             self.assertListEqual(
-                CPU.pretty_value.__get__(cpu_instance_mock),
-                [("CPU", "CPU-MODEL-NAME, 2 x ANOTHER-CPU-MODEL")],
+                list(cpu_instance_mock),
+                [("CPU", "CPU-MODEL-NAME"), ("CPU", "2 x ANOTHER-CPU-MODEL")],
             )
 
-        with self.subTest("Single-line combined output (no count)."):
+        with self.subTest("Normal output (no count)."):
             cpu_instance_mock.options["show_cores"] = False
             cpu_instance_mock.options["one_line"] = True
             self.assertListEqual(
-                CPU.pretty_value.__get__(cpu_instance_mock),
-                [("CPU", "CPU-MODEL-NAME, ANOTHER-CPU-MODEL")],
-            )
-
-        with self.subTest("Multi-lines output (with counts)."):
-            cpu_instance_mock.options["show_cores"] = True
-            cpu_instance_mock.options["one_line"] = False
-            self.assertListEqual(
-                CPU.pretty_value.__get__(cpu_instance_mock),
-                [("CPU", "CPU-MODEL-NAME"), ("CPU", "2 x ANOTHER-CPU-MODEL")],
+                list(cpu_instance_mock),
+                [("CPU", "CPU-MODEL-NAME"), ("CPU", "ANOTHER-CPU-MODEL")],
             )
 
         with self.subTest("No CPU detected output."):
             cpu_instance_mock.value = []
             self.assertListEqual(
-                CPU.pretty_value.__get__(cpu_instance_mock),
-                [("CPU", DEFAULT_CONFIG["default_strings"]["not_detected"])],
+                list(cpu_instance_mock),
+                [],
             )
 
     @patch(

--- a/archey/test/entries/test_archey_custom.py
+++ b/archey/test/entries/test_archey_custom.py
@@ -3,7 +3,7 @@
 import os
 import stat
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 from archey.configuration import DEFAULT_CONFIG, Configuration
 from archey.entries.custom import Custom
@@ -72,43 +72,25 @@ class TestCustomEntry(unittest.TestCase):
         )
         self.assertListEqual(custom.value, ["Model 1", "Model 2"])
 
-        output_mock = MagicMock()
-
         with self.subTest("Single-line combined output."):
             custom.options["one_line"] = True
-
-            custom.output(output_mock)
-
-            output_mock.append.assert_called_once_with("Custom", "Model 1, Model 2")
-
-        output_mock.reset_mock()
+            self.assertListEqual(custom.pretty_value, [("Custom", "Model 1, Model 2")])
 
         with self.subTest("Multi-lines combined output."):
             custom.options["one_line"] = False
-
-            custom.output(output_mock)
-
-            self.assertEqual(output_mock.append.call_count, 2)
-            output_mock.append.assert_has_calls(
+            self.assertListEqual(
+                custom.pretty_value,
                 [
-                    call("Custom", "Model 1"),
-                    call("Custom", "Model 2"),
-                ]
+                    ("Custom", "Model 1"),
+                    ("Custom", "Model 2"),
+                ],
             )
-
-        output_mock.reset_mock()
 
         with self.subTest("No detected output."):
             custom.value = []
-
-            custom.output(output_mock)
-
-            output_mock.append.assert_called_once_with(
-                "Custom",
-                DEFAULT_CONFIG["default_strings"]["not_detected"],
+            self.assertListEqual(
+                custom.pretty_value, [("Custom", DEFAULT_CONFIG["default_strings"]["not_detected"])]
             )
-
-        output_mock.reset_mock()
 
     def test_unsafe_config_files(self):
         """Check unsafe configuration files lead to Custom entry loading prevention"""

--- a/archey/test/entries/test_archey_custom.py
+++ b/archey/test/entries/test_archey_custom.py
@@ -5,7 +5,7 @@ import stat
 import unittest
 from unittest.mock import patch
 
-from archey.configuration import DEFAULT_CONFIG, Configuration
+from archey.configuration import Configuration
 from archey.entries.custom import Custom
 
 
@@ -62,8 +62,8 @@ class TestCustomEntry(unittest.TestCase):
         )
         self.assertIsNone(custom.value, None)
 
-    def test_multiple_lines_command_output(self) -> None:
-        """Check multiple lines command output"""
+    def test_output(self) -> None:
+        """Check command output"""
         custom = Custom(
             options={
                 "shell": True,
@@ -72,14 +72,10 @@ class TestCustomEntry(unittest.TestCase):
         )
         self.assertListEqual(custom.value, ["Model 1", "Model 2"])
 
-        with self.subTest("Single-line combined output."):
-            custom.options["one_line"] = True
-            self.assertListEqual(custom.pretty_value, [("Custom", "Model 1, Model 2")])
-
-        with self.subTest("Multi-lines combined output."):
+        with self.subTest("Normal output."):
             custom.options["one_line"] = False
             self.assertListEqual(
-                custom.pretty_value,
+                list(custom),
                 [
                     ("Custom", "Model 1"),
                     ("Custom", "Model 2"),
@@ -89,7 +85,8 @@ class TestCustomEntry(unittest.TestCase):
         with self.subTest("No detected output."):
             custom.value = []
             self.assertListEqual(
-                custom.pretty_value, [("Custom", DEFAULT_CONFIG["default_strings"]["not_detected"])]
+                list(custom),
+                [],
             )
 
     def test_unsafe_config_files(self):

--- a/archey/test/entries/test_archey_disk.py
+++ b/archey/test/entries/test_archey_disk.py
@@ -382,8 +382,8 @@ class TestDiskEntry(unittest.TestCase):
                     test_case[1],
                 )
 
-    def test_disk_pretty_value_colors(self):
-        """Test `pretty_value` output disk level coloring."""
+    def test_disk_colors(self):
+        """Test output disk level coloring."""
         # This dict's values are tuples of used blocks, and the level's corresponding color.
         # For reference, this test uses a disk whose total block count is 100.
         levels = {
@@ -401,7 +401,7 @@ class TestDiskEntry(unittest.TestCase):
                     }
                 }
                 self.assertListEqual(
-                    Disk.pretty_value.__get__(self.disk_instance_mock),
+                    list(self.disk_instance_mock),
                     [
                         (
                             "Disk",
@@ -411,8 +411,8 @@ class TestDiskEntry(unittest.TestCase):
                     ],
                 )
 
-    def test_disk_multiline_pretty_value(self):
-        """Test `pretty_value`'s multi-line capability."""
+    def test_disk_output(self):
+        """Test multi-line capability."""
         self.disk_instance_mock.value = {
             "first_mount_point": {
                 "device_path": "/dev/my-cool-disk",
@@ -428,14 +428,14 @@ class TestDiskEntry(unittest.TestCase):
 
         with self.subTest("Single-line combined output."):
             self.assertListEqual(
-                Disk.pretty_value.__get__(self.disk_instance_mock),
+                list(self.disk_instance_mock),
                 [("Disk", f"{Colors.YELLOW_NORMAL}20.0 KiB{Colors.CLEAR} / 40.0 KiB")],
             )
 
-        with self.subTest("Multi-line output"):
+        with self.subTest("Normal output"):
             self.disk_instance_mock.options["combine_total"] = False
             self.assertListEqual(
-                Disk.pretty_value.__get__(self.disk_instance_mock),
+                list(self.disk_instance_mock),
                 [
                     ("Disk", f"{Colors.RED_NORMAL}10.0 KiB{Colors.CLEAR} / 10.0 KiB"),
                     ("Disk", f"{Colors.GREEN_NORMAL}10.0 KiB{Colors.CLEAR} / 30.0 KiB"),
@@ -448,7 +448,7 @@ class TestDiskEntry(unittest.TestCase):
                 "disk_labels": "device_paths",
             }
             self.assertListEqual(
-                Disk.pretty_value.__get__(self.disk_instance_mock),
+                list(self.disk_instance_mock),
                 [
                     (
                         "Disk (/dev/my-cool-disk)",
@@ -468,7 +468,7 @@ class TestDiskEntry(unittest.TestCase):
                 "hide_entry_name": True,
             }
             self.assertListEqual(
-                Disk.pretty_value.__get__(self.disk_instance_mock),
+                list(self.disk_instance_mock),
                 [
                     (
                         "(first_mount_point)",
@@ -489,7 +489,7 @@ class TestDiskEntry(unittest.TestCase):
                 "hide_entry_name": True,
             }
             self.assertListEqual(
-                Disk.pretty_value.__get__(self.disk_instance_mock),
+                list(self.disk_instance_mock),
                 [
                     ("Disk", f"{Colors.RED_NORMAL}10.0 KiB{Colors.CLEAR} / 10.0 KiB"),
                     ("Disk", f"{Colors.GREEN_NORMAL}10.0 KiB{Colors.CLEAR} / 30.0 KiB"),

--- a/archey/test/entries/test_archey_distro.py
+++ b/archey/test/entries/test_archey_distro.py
@@ -3,9 +3,7 @@
 import unittest
 from unittest.mock import patch
 
-from archey.configuration import DEFAULT_CONFIG
 from archey.entries.distro import Distro
-from archey.test.entries import HelperMethods
 
 
 class TestDistroEntry(unittest.TestCase):
@@ -42,26 +40,6 @@ class TestDistroEntry(unittest.TestCase):
         self.assertEqual(
             Distro._fetch_darwin_release(),  # pylint: disable=protected-access
             "macOS 11.1",
-        )
-
-    @HelperMethods.patch_clean_configuration
-    def test_unknown_distro_pretty_value(self):
-        """Test for `pretty_value` property when distribution name couldn't be found"""
-        distro_instance_mock = HelperMethods.entry_mock(Distro)
-
-        distro_instance_mock.value = {
-            "name": None,
-            "arch": "ARCHITECTURE",
-        }
-
-        self.assertListEqual(
-            Distro.pretty_value.__get__(distro_instance_mock),
-            [
-                (
-                    distro_instance_mock.name,
-                    f"{DEFAULT_CONFIG['default_strings']['not_detected']} ARCHITECTURE",
-                )
-            ],
         )
 
 

--- a/archey/test/entries/test_archey_distro.py
+++ b/archey/test/entries/test_archey_distro.py
@@ -1,7 +1,7 @@
 """Test module for Archey's distribution detection module"""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.distro import Distro
@@ -45,20 +45,23 @@ class TestDistroEntry(unittest.TestCase):
         )
 
     @HelperMethods.patch_clean_configuration
-    def test_unknown_distro_output(self):
-        """Test for `output` method when distribution name couldn't be found"""
-        distro_intance_mock = HelperMethods.entry_mock(Distro)
-        output_mock = MagicMock()
+    def test_unknown_distro_pretty_value(self):
+        """Test for `pretty_value` property when distribution name couldn't be found"""
+        distro_instance_mock = HelperMethods.entry_mock(Distro)
 
-        distro_intance_mock.value = {
+        distro_instance_mock.value = {
             "name": None,
             "arch": "ARCHITECTURE",
         }
 
-        Distro.output(distro_intance_mock, output_mock)
-        self.assertEqual(
-            output_mock.append.call_args[0][1],
-            f"{DEFAULT_CONFIG['default_strings']['not_detected']} ARCHITECTURE",
+        self.assertListEqual(
+            Distro.pretty_value.__get__(distro_instance_mock),
+            [
+                (
+                    distro_instance_mock.name,
+                    f"{DEFAULT_CONFIG['default_strings']['not_detected']} ARCHITECTURE",
+                )
+            ],
         )
 
 

--- a/archey/test/entries/test_archey_gpu.py
+++ b/archey/test/entries/test_archey_gpu.py
@@ -1,7 +1,7 @@
 """Test module for Archey's GPU detection module"""
 
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.gpu import GPU
@@ -176,9 +176,8 @@ vgapci0@pci0:16:0:0:  class=0x030000 card=0x3381103c chip=0x0533102b rev=0x00 hd
 
     @HelperMethods.patch_clean_configuration
     def test_various_output_configuration(self):
-        """Test `output` overloading based on user preferences"""
+        """Test `pretty_value` output overloading based on user preferences"""
         gpu_instance_mock = HelperMethods.entry_mock(GPU)
-        output_mock = MagicMock()
 
         gpu_instance_mock.value = [
             "3D GPU-MODEL-NAME TAKES ADVANTAGE",
@@ -189,34 +188,32 @@ vgapci0@pci0:16:0:0:  class=0x030000 card=0x3381103c chip=0x0533102b rev=0x00 hd
         with self.subTest("Single-line combined output."):
             gpu_instance_mock.options["one_line"] = True
 
-            GPU.output(gpu_instance_mock, output_mock)
-            output_mock.append.assert_called_once_with(
-                "GPU", "3D GPU-MODEL-NAME TAKES ADVANTAGE, GPU-MODEL-NAME, ANOTHER-MATCHING-VIDEO"
+            self.assertListEqual(
+                GPU.pretty_value.__get__(gpu_instance_mock),
+                [
+                    (
+                        "GPU",
+                        "3D GPU-MODEL-NAME TAKES ADVANTAGE, GPU-MODEL-NAME, ANOTHER-MATCHING-VIDEO",
+                    )
+                ],
             )
-
-        output_mock.reset_mock()
 
         with self.subTest("Multi-lines output."):
             gpu_instance_mock.options["one_line"] = False
-
-            GPU.output(gpu_instance_mock, output_mock)
-            self.assertEqual(output_mock.append.call_count, 3)
-            output_mock.append.assert_has_calls(
+            self.assertListEqual(
+                GPU.pretty_value.__get__(gpu_instance_mock),
                 [
-                    call("GPU", "3D GPU-MODEL-NAME TAKES ADVANTAGE"),
-                    call("GPU", "GPU-MODEL-NAME"),
-                    call("GPU", "ANOTHER-MATCHING-VIDEO"),
-                ]
+                    ("GPU", "3D GPU-MODEL-NAME TAKES ADVANTAGE"),
+                    ("GPU", "GPU-MODEL-NAME"),
+                    ("GPU", "ANOTHER-MATCHING-VIDEO"),
+                ],
             )
-
-        output_mock.reset_mock()
 
         with self.subTest("No GPU detected output."):
             gpu_instance_mock.value = []
-
-            GPU.output(gpu_instance_mock, output_mock)
-            output_mock.append.assert_called_once_with(
-                "GPU", DEFAULT_CONFIG["default_strings"]["not_detected"]
+            self.assertListEqual(
+                GPU.pretty_value.__get__(gpu_instance_mock),
+                [("GPU", DEFAULT_CONFIG["default_strings"]["not_detected"])],
             )
 
 

--- a/archey/test/entries/test_archey_gpu.py
+++ b/archey/test/entries/test_archey_gpu.py
@@ -3,7 +3,6 @@
 import unittest
 from unittest.mock import patch
 
-from archey.configuration import DEFAULT_CONFIG
 from archey.entries.gpu import GPU
 from archey.test import CustomAssertions
 from archey.test.entries import HelperMethods
@@ -176,7 +175,7 @@ vgapci0@pci0:16:0:0:  class=0x030000 card=0x3381103c chip=0x0533102b rev=0x00 hd
 
     @HelperMethods.patch_clean_configuration
     def test_various_output_configuration(self):
-        """Test `pretty_value` output overloading based on user preferences"""
+        """Test `__iter__` and `__next__` output overloading based on user preferences"""
         gpu_instance_mock = HelperMethods.entry_mock(GPU)
 
         gpu_instance_mock.value = [
@@ -185,23 +184,9 @@ vgapci0@pci0:16:0:0:  class=0x030000 card=0x3381103c chip=0x0533102b rev=0x00 hd
             "ANOTHER-MATCHING-VIDEO",
         ]
 
-        with self.subTest("Single-line combined output."):
-            gpu_instance_mock.options["one_line"] = True
-
+        with self.subTest("Normal output."):
             self.assertListEqual(
-                GPU.pretty_value.__get__(gpu_instance_mock),
-                [
-                    (
-                        "GPU",
-                        "3D GPU-MODEL-NAME TAKES ADVANTAGE, GPU-MODEL-NAME, ANOTHER-MATCHING-VIDEO",
-                    )
-                ],
-            )
-
-        with self.subTest("Multi-lines output."):
-            gpu_instance_mock.options["one_line"] = False
-            self.assertListEqual(
-                GPU.pretty_value.__get__(gpu_instance_mock),
+                list(gpu_instance_mock),
                 [
                     ("GPU", "3D GPU-MODEL-NAME TAKES ADVANTAGE"),
                     ("GPU", "GPU-MODEL-NAME"),
@@ -212,8 +197,8 @@ vgapci0@pci0:16:0:0:  class=0x030000 card=0x3381103c chip=0x0533102b rev=0x00 hd
         with self.subTest("No GPU detected output."):
             gpu_instance_mock.value = []
             self.assertListEqual(
-                GPU.pretty_value.__get__(gpu_instance_mock),
-                [("GPU", DEFAULT_CONFIG["default_strings"]["not_detected"])],
+                list(gpu_instance_mock),
+                [],
             )
 
 

--- a/archey/test/entries/test_archey_kernel.py
+++ b/archey/test/entries/test_archey_kernel.py
@@ -1,7 +1,7 @@
 """Test module for Archey's kernel information detection module"""
 
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.kernel import Kernel
@@ -131,33 +131,31 @@ class TestKernelEntry(unittest.TestCase):
     @HelperMethods.patch_clean_configuration
     def test_kernel_comparison(self, _, __, ___):
         """Check kernel releases comparison and output templates"""
-        output_mock = MagicMock()
-
         # Only current release (`check_version` disabled by default).
         kernel = Kernel()
-        kernel.output(output_mock)
-        self.assertEqual(output_mock.append.call_args[0][1], "Linux 1.2.3-4-arch")
+        self.assertListEqual(kernel.pretty_value, [(kernel.name, "Linux 1.2.3-4-arch")])
 
         # Current = latest (up to date !).
         kernel = Kernel(options={"check_version": True})
-        kernel.output(output_mock)
-
         self.assertTrue(kernel.value["latest"])
         self.assertIs(kernel.value["is_outdated"], False)
-        self.assertEqual(
-            output_mock.append.call_args[0][1],
-            f"Linux 1.2.3-4-arch ({DEFAULT_CONFIG['default_strings']['latest']})",
+        self.assertListEqual(
+            kernel.pretty_value,
+            [(kernel.name, f"Linux 1.2.3-4-arch ({DEFAULT_CONFIG['default_strings']['latest']})")],
         )
 
         # Current < latest (outdated).
         kernel = Kernel(options={"check_version": True})
-        kernel.output(output_mock)
-
         self.assertTrue(kernel.value["latest"])
         self.assertIs(kernel.value["is_outdated"], True)
-        self.assertEqual(
-            output_mock.append.call_args[0][1],
-            f"Linux 1.2.3-4-arch (1.3.2 {DEFAULT_CONFIG['default_strings']['available']})",
+        self.assertListEqual(
+            kernel.pretty_value,
+            [
+                (
+                    kernel.name,
+                    f"Linux 1.2.3-4-arch (1.3.2 {DEFAULT_CONFIG['default_strings']['available']})",
+                )
+            ],
         )
 
 

--- a/archey/test/entries/test_archey_kernel.py
+++ b/archey/test/entries/test_archey_kernel.py
@@ -133,14 +133,14 @@ class TestKernelEntry(unittest.TestCase):
         """Check kernel releases comparison and output templates"""
         # Only current release (`check_version` disabled by default).
         kernel = Kernel()
-        self.assertListEqual(kernel.pretty_value, [(kernel.name, "Linux 1.2.3-4-arch")])
+        self.assertListEqual(list(kernel), [(kernel.name, "Linux 1.2.3-4-arch")])
 
         # Current = latest (up to date !).
         kernel = Kernel(options={"check_version": True})
         self.assertTrue(kernel.value["latest"])
         self.assertIs(kernel.value["is_outdated"], False)
         self.assertListEqual(
-            kernel.pretty_value,
+            list(kernel),
             [(kernel.name, f"Linux 1.2.3-4-arch ({DEFAULT_CONFIG['default_strings']['latest']})")],
         )
 
@@ -149,7 +149,7 @@ class TestKernelEntry(unittest.TestCase):
         self.assertTrue(kernel.value["latest"])
         self.assertIs(kernel.value["is_outdated"], True)
         self.assertListEqual(
-            kernel.pretty_value,
+            list(kernel),
             [
                 (
                     kernel.name,

--- a/archey/test/entries/test_archey_lan_ip.py
+++ b/archey/test/entries/test_archey_lan_ip.py
@@ -229,17 +229,9 @@ class TestLanIPEntry(unittest.TestCase, CustomAssertions):
             ["192.168.1.55", "2001::45:6789:abcd:6817", "fe80::abcd:ef0:abef:dead"],
         )
 
-        with self.subTest("Single-line combined output."):
+        with self.subTest("Normal output."):
             self.assertListEqual(
-                lan_ip.pretty_value,
-                [(lan_ip.name, "192.168.1.55, 2001::45:6789:abcd:6817, fe80::abcd:ef0:abef:dead")],
-            )
-
-        with self.subTest("Multi-lines output."):
-            lan_ip.options["one_line"] = False
-
-            self.assertListEqual(
-                lan_ip.pretty_value,
+                list(lan_ip),
                 [
                     (lan_ip.name, "192.168.1.55"),
                     (lan_ip.name, "2001::45:6789:abcd:6817"),
@@ -351,7 +343,7 @@ class TestLanIPEntry(unittest.TestCase, CustomAssertions):
         lan_ip = LanIP()
         self.assertListEmpty(lan_ip.value)
         self.assertListEqual(
-            lan_ip.pretty_value,
+            list(lan_ip),
             [(lan_ip.name, DEFAULT_CONFIG["default_strings"]["no_address"])],
         )
 
@@ -408,7 +400,7 @@ class TestLanIPEntry(unittest.TestCase, CustomAssertions):
         lan_ip = LanIP(options={"max_count": 0})
         self.assertListEmpty(lan_ip.value)
         self.assertListEqual(
-            lan_ip.pretty_value,
+            list(lan_ip),
             [(lan_ip.name, DEFAULT_CONFIG["default_strings"]["no_address"])],
         )
 
@@ -419,8 +411,8 @@ class TestLanIPEntry(unittest.TestCase, CustomAssertions):
         lan_ip = LanIP()
         self.assertIsNone(lan_ip.value)
         self.assertListEqual(
-            lan_ip.pretty_value,
-            [(lan_ip.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
+            list(lan_ip),
+            [],
         )
 
 

--- a/archey/test/entries/test_archey_load_average.py
+++ b/archey/test/entries/test_archey_load_average.py
@@ -23,16 +23,9 @@ class TestLoadAverageEntry(unittest.TestCase):
             "danger_threshold": 2.25,
         }
 
-        self.assertListEqual(
-            list(self.load_average_mock),
-            [
-                (
-                    self.load_average_mock.name,
-                    f"{Colors.GREEN_NORMAL}0.5{Colors.CLEAR} "
-                    f"{Colors.YELLOW_NORMAL}1.25{Colors.CLEAR} "
-                    f"{Colors.RED_NORMAL}2.5{Colors.CLEAR}",
-                )
-            ],
+        self.assertEqual(
+            str(self.load_average_mock),
+            f"{Colors.GREEN_NORMAL}0.5{Colors.CLEAR} {Colors.YELLOW_NORMAL}1.25{Colors.CLEAR} {Colors.RED_NORMAL}2.5{Colors.CLEAR}",
         )
 
     @HelperMethods.patch_clean_configuration
@@ -46,16 +39,9 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "warning_threshold": 5,
                 "danger_threshold": 5,
             }
-            self.assertListEqual(
-                list(self.load_average_mock),
-                [
-                    (
-                        self.load_average_mock.name,
-                        f"{Colors.GREEN_NORMAL}0.0{Colors.CLEAR} "
-                        f"{Colors.GREEN_NORMAL}1.0{Colors.CLEAR} "
-                        f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
-                    )
-                ],
+            self.assertEqual(
+                str(self.load_average_mock),
+                f"{Colors.GREEN_NORMAL}0.0{Colors.CLEAR} {Colors.GREEN_NORMAL}1.0{Colors.CLEAR} {Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
             )
 
         with self.subTest("1 decimal place"):
@@ -64,16 +50,9 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "warning_threshold": 5,
                 "danger_threshold": 5,
             }
-            self.assertListEqual(
-                list(self.load_average_mock),
-                [
-                    (
-                        self.load_average_mock.name,
-                        f"{Colors.GREEN_NORMAL}0.3{Colors.CLEAR} "
-                        f"{Colors.GREEN_NORMAL}1.2{Colors.CLEAR} "
-                        f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
-                    )
-                ],
+            self.assertEqual(
+                str(self.load_average_mock),
+                f"{Colors.GREEN_NORMAL}0.3{Colors.CLEAR} {Colors.GREEN_NORMAL}1.2{Colors.CLEAR} {Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
             )
 
         with self.subTest("2 decimal places"):
@@ -82,16 +61,9 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "warning_threshold": 5,
                 "danger_threshold": 5,
             }
-            self.assertListEqual(
-                list(self.load_average_mock),
-                [
-                    (
-                        self.load_average_mock.name,
-                        f"{Colors.GREEN_NORMAL}0.33{Colors.CLEAR} "
-                        f"{Colors.GREEN_NORMAL}1.25{Colors.CLEAR} "
-                        f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
-                    )
-                ],
+            self.assertEqual(
+                str(self.load_average_mock),
+                f"{Colors.GREEN_NORMAL}0.33{Colors.CLEAR} {Colors.GREEN_NORMAL}1.25{Colors.CLEAR} {Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
             )
 
 

--- a/archey/test/entries/test_archey_load_average.py
+++ b/archey/test/entries/test_archey_load_average.py
@@ -1,7 +1,6 @@
 """Test module for Archey LoadAverage detection module"""
 
 import unittest
-from unittest.mock import MagicMock
 
 from archey.colors import Colors
 from archey.entries.load_average import LoadAverage
@@ -9,33 +8,36 @@ from archey.test.entries import HelperMethods
 
 
 class TestLoadAverageEntry(unittest.TestCase):
-    """LoadAverage `output` configuration-based coloration test class"""
+    """LoadAverage `pretty_value` configuration-based coloration test class"""
 
     def setUp(self):
         """Define mocked entry before each test"""
         self.load_average_mock = HelperMethods.entry_mock(LoadAverage)
-        self.output_mock = MagicMock()
 
     @HelperMethods.patch_clean_configuration
-    def test_output_coloration(self):
-        """Test `output` coloration based on user preferences"""
+    def test_pretty_value_coloration(self):
+        """Test `pretty_value` output coloration based on user preferences"""
         self.load_average_mock.value = (0.5, 1.25, 2.5)
         self.load_average_mock.options = {
             "warning_threshold": 0.75,
             "danger_threshold": 2.25,
         }
 
-        LoadAverage.output(self.load_average_mock, self.output_mock)
-        self.assertEqual(
-            self.output_mock.append.call_args[0][1],
-            f"{Colors.GREEN_NORMAL}0.5{Colors.CLEAR} "
-            f"{Colors.YELLOW_NORMAL}1.25{Colors.CLEAR} "
-            f"{Colors.RED_NORMAL}2.5{Colors.CLEAR}",
+        self.assertListEqual(
+            LoadAverage.pretty_value.__get__(self.load_average_mock),
+            [
+                (
+                    self.load_average_mock.name,
+                    f"{Colors.GREEN_NORMAL}0.5{Colors.CLEAR} "
+                    f"{Colors.YELLOW_NORMAL}1.25{Colors.CLEAR} "
+                    f"{Colors.RED_NORMAL}2.5{Colors.CLEAR}",
+                )
+            ],
         )
 
     @HelperMethods.patch_clean_configuration
-    def test_output_rounding(self):
-        """Test `output` rounding based on user preferences"""
+    def test_pretty_value_rounding(self):
+        """Test `pretty_value` output rounding based on user preferences"""
         self.load_average_mock.value = (0.33333, 1.25, 2.0)
 
         with self.subTest("No decimal places"):
@@ -44,12 +46,16 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "warning_threshold": 5,
                 "danger_threshold": 5,
             }
-            LoadAverage.output(self.load_average_mock, self.output_mock)
-            self.assertEqual(
-                self.output_mock.append.call_args[0][1],
-                f"{Colors.GREEN_NORMAL}0.0{Colors.CLEAR} "
-                f"{Colors.GREEN_NORMAL}1.0{Colors.CLEAR} "
-                f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+            self.assertListEqual(
+                LoadAverage.pretty_value.__get__(self.load_average_mock),
+                [
+                    (
+                        self.load_average_mock.name,
+                        f"{Colors.GREEN_NORMAL}0.0{Colors.CLEAR} "
+                        f"{Colors.GREEN_NORMAL}1.0{Colors.CLEAR} "
+                        f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+                    )
+                ],
             )
 
         with self.subTest("1 decimal place"):
@@ -58,12 +64,16 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "warning_threshold": 5,
                 "danger_threshold": 5,
             }
-            LoadAverage.output(self.load_average_mock, self.output_mock)
-            self.assertEqual(
-                self.output_mock.append.call_args[0][1],
-                f"{Colors.GREEN_NORMAL}0.3{Colors.CLEAR} "
-                f"{Colors.GREEN_NORMAL}1.2{Colors.CLEAR} "
-                f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+            self.assertListEqual(
+                LoadAverage.pretty_value.__get__(self.load_average_mock),
+                [
+                    (
+                        self.load_average_mock.name,
+                        f"{Colors.GREEN_NORMAL}0.3{Colors.CLEAR} "
+                        f"{Colors.GREEN_NORMAL}1.2{Colors.CLEAR} "
+                        f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+                    )
+                ],
             )
 
         with self.subTest("2 decimal places"):
@@ -72,12 +82,16 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "warning_threshold": 5,
                 "danger_threshold": 5,
             }
-            LoadAverage.output(self.load_average_mock, self.output_mock)
-            self.assertEqual(
-                self.output_mock.append.call_args[0][1],
-                f"{Colors.GREEN_NORMAL}0.33{Colors.CLEAR} "
-                f"{Colors.GREEN_NORMAL}1.25{Colors.CLEAR} "
-                f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+            self.assertListEqual(
+                LoadAverage.pretty_value.__get__(self.load_average_mock),
+                [
+                    (
+                        self.load_average_mock.name,
+                        f"{Colors.GREEN_NORMAL}0.33{Colors.CLEAR} "
+                        f"{Colors.GREEN_NORMAL}1.25{Colors.CLEAR} "
+                        f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+                    )
+                ],
             )
 
 

--- a/archey/test/entries/test_archey_load_average.py
+++ b/archey/test/entries/test_archey_load_average.py
@@ -16,7 +16,7 @@ class TestLoadAverageEntry(unittest.TestCase):
 
     @HelperMethods.patch_clean_configuration
     def test_pretty_value_coloration(self):
-        """Test `pretty_value` output coloration based on user preferences"""
+        """Test output coloration based on user preferences"""
         self.load_average_mock.value = (0.5, 1.25, 2.5)
         self.load_average_mock.options = {
             "warning_threshold": 0.75,
@@ -24,7 +24,7 @@ class TestLoadAverageEntry(unittest.TestCase):
         }
 
         self.assertListEqual(
-            LoadAverage.pretty_value.__get__(self.load_average_mock),
+            list(self.load_average_mock),
             [
                 (
                     self.load_average_mock.name,
@@ -37,7 +37,7 @@ class TestLoadAverageEntry(unittest.TestCase):
 
     @HelperMethods.patch_clean_configuration
     def test_pretty_value_rounding(self):
-        """Test `pretty_value` output rounding based on user preferences"""
+        """Test output rounding based on user preferences"""
         self.load_average_mock.value = (0.33333, 1.25, 2.0)
 
         with self.subTest("No decimal places"):
@@ -47,7 +47,7 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "danger_threshold": 5,
             }
             self.assertListEqual(
-                LoadAverage.pretty_value.__get__(self.load_average_mock),
+                list(self.load_average_mock),
                 [
                     (
                         self.load_average_mock.name,
@@ -65,7 +65,7 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "danger_threshold": 5,
             }
             self.assertListEqual(
-                LoadAverage.pretty_value.__get__(self.load_average_mock),
+                list(self.load_average_mock),
                 [
                     (
                         self.load_average_mock.name,
@@ -83,7 +83,7 @@ class TestLoadAverageEntry(unittest.TestCase):
                 "danger_threshold": 5,
             }
             self.assertListEqual(
-                LoadAverage.pretty_value.__get__(self.load_average_mock),
+                list(self.load_average_mock),
                 [
                     (
                         self.load_average_mock.name,

--- a/archey/test/entries/test_archey_load_average.py
+++ b/archey/test/entries/test_archey_load_average.py
@@ -25,7 +25,11 @@ class TestLoadAverageEntry(unittest.TestCase):
 
         self.assertEqual(
             str(self.load_average_mock),
-            f"{Colors.GREEN_NORMAL}0.5{Colors.CLEAR} {Colors.YELLOW_NORMAL}1.25{Colors.CLEAR} {Colors.RED_NORMAL}2.5{Colors.CLEAR}",
+            (
+                f"{Colors.GREEN_NORMAL}0.5{Colors.CLEAR} "
+                f"{Colors.YELLOW_NORMAL}1.25{Colors.CLEAR} "
+                f"{Colors.RED_NORMAL}2.5{Colors.CLEAR}"
+            ),
         )
 
     @HelperMethods.patch_clean_configuration
@@ -41,7 +45,11 @@ class TestLoadAverageEntry(unittest.TestCase):
             }
             self.assertEqual(
                 str(self.load_average_mock),
-                f"{Colors.GREEN_NORMAL}0.0{Colors.CLEAR} {Colors.GREEN_NORMAL}1.0{Colors.CLEAR} {Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+                (
+                    f"{Colors.GREEN_NORMAL}0.0{Colors.CLEAR} "
+                    f"{Colors.GREEN_NORMAL}1.0{Colors.CLEAR} "
+                    f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}"
+                ),
             )
 
         with self.subTest("1 decimal place"):
@@ -52,7 +60,11 @@ class TestLoadAverageEntry(unittest.TestCase):
             }
             self.assertEqual(
                 str(self.load_average_mock),
-                f"{Colors.GREEN_NORMAL}0.3{Colors.CLEAR} {Colors.GREEN_NORMAL}1.2{Colors.CLEAR} {Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+                (
+                    f"{Colors.GREEN_NORMAL}0.3{Colors.CLEAR} "
+                    f"{Colors.GREEN_NORMAL}1.2{Colors.CLEAR} "
+                    f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}"
+                ),
             )
 
         with self.subTest("2 decimal places"):
@@ -63,7 +75,11 @@ class TestLoadAverageEntry(unittest.TestCase):
             }
             self.assertEqual(
                 str(self.load_average_mock),
-                f"{Colors.GREEN_NORMAL}0.33{Colors.CLEAR} {Colors.GREEN_NORMAL}1.25{Colors.CLEAR} {Colors.GREEN_NORMAL}2.0{Colors.CLEAR}",
+                (
+                    f"{Colors.GREEN_NORMAL}0.33{Colors.CLEAR} "
+                    f"{Colors.GREEN_NORMAL}1.25{Colors.CLEAR} "
+                    f"{Colors.GREEN_NORMAL}2.0{Colors.CLEAR}"
+                ),
             )
 
 

--- a/archey/test/entries/test_archey_model.py
+++ b/archey/test/entries/test_archey_model.py
@@ -4,7 +4,6 @@ import unittest
 from subprocess import CalledProcessError
 from unittest.mock import mock_open, patch
 
-from archey.configuration import DEFAULT_CONFIG
 from archey.entries.model import Model
 from archey.test.entries import HelperMethods
 
@@ -251,8 +250,8 @@ class TestModelEntry(unittest.TestCase):
         model_instance_mock = HelperMethods.entry_mock(Model)
         self.assertIsNone(model_instance_mock.value)
         self.assertListEqual(
-            Model.pretty_value.__get__(model_instance_mock),
-            [(model_instance_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
+            list(model_instance_mock),
+            [(model_instance_mock.name, None)],
         )
 
     @patch(

--- a/archey/test/entries/test_archey_model.py
+++ b/archey/test/entries/test_archey_model.py
@@ -2,7 +2,7 @@
 
 import unittest
 from subprocess import CalledProcessError
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import mock_open, patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.model import Model
@@ -249,13 +249,10 @@ class TestModelEntry(unittest.TestCase):
     def test_no_match(self):
         """Test when no information could be retrieved"""
         model_instance_mock = HelperMethods.entry_mock(Model)
-
-        output_mock = MagicMock()
-        Model.output(model_instance_mock, output_mock)
-
         self.assertIsNone(model_instance_mock.value)
-        self.assertEqual(
-            output_mock.append.call_args[0][1], DEFAULT_CONFIG["default_strings"]["not_detected"]
+        self.assertListEqual(
+            Model.pretty_value.__get__(model_instance_mock),
+            [(model_instance_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
         )
 
     @patch(

--- a/archey/test/entries/test_archey_model.py
+++ b/archey/test/entries/test_archey_model.py
@@ -249,10 +249,6 @@ class TestModelEntry(unittest.TestCase):
         """Test when no information could be retrieved"""
         model_instance_mock = HelperMethods.entry_mock(Model)
         self.assertIsNone(model_instance_mock.value)
-        self.assertListEqual(
-            list(model_instance_mock),
-            [(model_instance_mock.name, None)],
-        )
 
     @patch(
         "archey.entries.model.check_output",

--- a/archey/test/entries/test_archey_packages.py
+++ b/archey/test/entries/test_archey_packages.py
@@ -2,7 +2,7 @@
 
 import unittest
 from unittest.mock import DEFAULT as DEFAULT_SENTINEL
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.distributions import Distributions
@@ -303,15 +303,12 @@ sample_package_2_2
     def test_no_packages_manager(self, check_output_mock):
         """No packages manager is available at the moment..."""
         check_output_mock.side_effect = self._check_output_side_effect()
-
         packages = Packages()
 
-        output_mock = MagicMock()
-        packages.output(output_mock)
-
         self.assertIsNone(packages.value)
-        self.assertEqual(
-            output_mock.append.call_args[0][1], DEFAULT_CONFIG["default_strings"]["not_detected"]
+        self.assertListEqual(
+            packages.pretty_value,
+            [(packages.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
         )
 
     @staticmethod

--- a/archey/test/entries/test_archey_packages.py
+++ b/archey/test/entries/test_archey_packages.py
@@ -305,10 +305,6 @@ sample_package_2_2
         packages = Packages()
 
         self.assertIsNone(packages.value)
-        self.assertListEqual(
-            list(packages),
-            [(packages.name, None)],
-        )
 
     @staticmethod
     def _check_output_side_effect(pkg_manager_cmd=None):

--- a/archey/test/entries/test_archey_packages.py
+++ b/archey/test/entries/test_archey_packages.py
@@ -4,7 +4,6 @@ import unittest
 from unittest.mock import DEFAULT as DEFAULT_SENTINEL
 from unittest.mock import patch
 
-from archey.configuration import DEFAULT_CONFIG
 from archey.distributions import Distributions
 from archey.entries.packages import Packages
 from archey.test.entries import HelperMethods
@@ -307,8 +306,8 @@ sample_package_2_2
 
         self.assertIsNone(packages.value)
         self.assertListEqual(
-            packages.pretty_value,
-            [(packages.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
+            list(packages),
+            [(packages.name, None)],
         )
 
     @staticmethod

--- a/archey/test/entries/test_archey_ram.py
+++ b/archey/test/entries/test_archey_ram.py
@@ -4,7 +4,6 @@ import unittest
 from unittest.mock import mock_open, patch
 
 from archey.colors import Colors
-from archey.configuration import DEFAULT_CONFIG
 from archey.entries.ram import RAM
 from archey.test.entries import HelperMethods
 
@@ -125,13 +124,13 @@ Swapouts:                               3456015.
 
     @HelperMethods.patch_clean_configuration
     def test_various_output_configuration(self):
-        """Test `pretty_value` output overloading based on user preferences"""
+        """Test output overloading based on user preferences"""
         ram_instance_mock = HelperMethods.entry_mock(RAM)
 
         with self.subTest("Output in case of non-detection."):
             self.assertListEqual(
-                RAM.pretty_value.__get__(ram_instance_mock),
-                [(ram_instance_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
+                list(ram_instance_mock),
+                [(ram_instance_mock.name, None)],
             )
 
         with self.subTest('"Normal" output (green).'):
@@ -145,7 +144,7 @@ Swapouts:                               3456015.
                 "danger_use_percent": 66.7,
             }
             self.assertListEqual(
-                RAM.pretty_value.__get__(ram_instance_mock),
+                list(ram_instance_mock),
                 [
                     (
                         ram_instance_mock.name,
@@ -165,7 +164,7 @@ Swapouts:                               3456015.
                 "danger_use_percent": 50,
             }
             self.assertListEqual(
-                RAM.pretty_value.__get__(ram_instance_mock),
+                list(ram_instance_mock),
                 [
                     (
                         ram_instance_mock.name,

--- a/archey/test/entries/test_archey_ram.py
+++ b/archey/test/entries/test_archey_ram.py
@@ -1,7 +1,7 @@
 """Test module for Archey's RAM usage detection module"""
 
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import mock_open, patch
 
 from archey.colors import Colors
 from archey.configuration import DEFAULT_CONFIG
@@ -125,18 +125,14 @@ Swapouts:                               3456015.
 
     @HelperMethods.patch_clean_configuration
     def test_various_output_configuration(self):
-        """Test `output` overloading based on user preferences"""
+        """Test `pretty_value` output overloading based on user preferences"""
         ram_instance_mock = HelperMethods.entry_mock(RAM)
-        output_mock = MagicMock()
 
         with self.subTest("Output in case of non-detection."):
-            RAM.output(ram_instance_mock, output_mock)
-            self.assertEqual(
-                output_mock.append.call_args[0][1],
-                DEFAULT_CONFIG["default_strings"]["not_detected"],
+            self.assertListEqual(
+                RAM.pretty_value.__get__(ram_instance_mock),
+                [(ram_instance_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
             )
-
-        output_mock.reset_mock()
 
         with self.subTest('"Normal" output (green).'):
             ram_instance_mock.value = {
@@ -148,14 +144,15 @@ Swapouts:                               3456015.
                 "warning_use_percent": 33.3,
                 "danger_use_percent": 66.7,
             }
-
-            RAM.output(ram_instance_mock, output_mock)
-            self.assertEqual(
-                output_mock.append.call_args[0][1],
-                f"{Colors.GREEN_NORMAL}2043 MiB{Colors.CLEAR} / 15658 MiB",
+            self.assertListEqual(
+                RAM.pretty_value.__get__(ram_instance_mock),
+                [
+                    (
+                        ram_instance_mock.name,
+                        f"{Colors.GREEN_NORMAL}2043 MiB{Colors.CLEAR} / 15658 MiB",
+                    )
+                ],
             )
-
-        output_mock.reset_mock()
 
         with self.subTest('"Danger" output (red).'):
             ram_instance_mock.value = {
@@ -167,11 +164,14 @@ Swapouts:                               3456015.
                 "warning_use_percent": 25,
                 "danger_use_percent": 50,
             }
-
-            RAM.output(ram_instance_mock, output_mock)
-            self.assertEqual(
-                output_mock.append.call_args[0][1],
-                f"{Colors.RED_NORMAL}7830 MiB{Colors.CLEAR} / 15658 MiB",
+            self.assertListEqual(
+                RAM.pretty_value.__get__(ram_instance_mock),
+                [
+                    (
+                        ram_instance_mock.name,
+                        f"{Colors.RED_NORMAL}7830 MiB{Colors.CLEAR} / 15658 MiB",
+                    )
+                ],
             )
 
 

--- a/archey/test/entries/test_archey_ram.py
+++ b/archey/test/entries/test_archey_ram.py
@@ -127,11 +127,8 @@ Swapouts:                               3456015.
         """Test output overloading based on user preferences"""
         ram_instance_mock = HelperMethods.entry_mock(RAM)
 
-        with self.subTest("Output in case of non-detection."):
-            self.assertListEqual(
-                list(ram_instance_mock),
-                [(ram_instance_mock.name, None)],
-            )
+        with self.subTest("In case of non-detection."):
+            self.assertIsNone(ram_instance_mock.value)
 
         with self.subTest('"Normal" output (green).'):
             ram_instance_mock.value = {
@@ -143,14 +140,9 @@ Swapouts:                               3456015.
                 "warning_use_percent": 33.3,
                 "danger_use_percent": 66.7,
             }
-            self.assertListEqual(
-                list(ram_instance_mock),
-                [
-                    (
-                        ram_instance_mock.name,
-                        f"{Colors.GREEN_NORMAL}2043 MiB{Colors.CLEAR} / 15658 MiB",
-                    )
-                ],
+            self.assertEqual(
+                str(ram_instance_mock),
+                f"{Colors.GREEN_NORMAL}2043 MiB{Colors.CLEAR} / 15658 MiB",
             )
 
         with self.subTest('"Danger" output (red).'):
@@ -163,14 +155,9 @@ Swapouts:                               3456015.
                 "warning_use_percent": 25,
                 "danger_use_percent": 50,
             }
-            self.assertListEqual(
-                list(ram_instance_mock),
-                [
-                    (
-                        ram_instance_mock.name,
-                        f"{Colors.RED_NORMAL}7830 MiB{Colors.CLEAR} / 15658 MiB",
-                    )
-                ],
+            self.assertEqual(
+                str(ram_instance_mock),
+                f"{Colors.RED_NORMAL}7830 MiB{Colors.CLEAR} / 15658 MiB",
             )
 
 

--- a/archey/test/entries/test_archey_shell.py
+++ b/archey/test/entries/test_archey_shell.py
@@ -2,7 +2,7 @@
 
 import unittest
 from subprocess import CalledProcessError
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.shell import Shell
@@ -59,13 +59,9 @@ class TestShellEntry(unittest.TestCase):
     def test_config_fall_back(self, _, __):
         """`id` fails, but Archey must not !"""
         shell = Shell()
-
-        output_mock = MagicMock()
-        shell.output(output_mock)
-
         self.assertIsNone(shell.value)
-        self.assertEqual(
-            output_mock.append.call_args[0][1], DEFAULT_CONFIG["default_strings"]["not_detected"]
+        self.assertListEqual(
+            shell.pretty_value, [(shell.name, DEFAULT_CONFIG["default_strings"]["not_detected"])]
         )
 
 

--- a/archey/test/entries/test_archey_shell.py
+++ b/archey/test/entries/test_archey_shell.py
@@ -4,7 +4,6 @@ import unittest
 from subprocess import CalledProcessError
 from unittest.mock import patch
 
-from archey.configuration import DEFAULT_CONFIG
 from archey.entries.shell import Shell
 from archey.test.entries import HelperMethods
 
@@ -61,7 +60,8 @@ class TestShellEntry(unittest.TestCase):
         shell = Shell()
         self.assertIsNone(shell.value)
         self.assertListEqual(
-            shell.pretty_value, [(shell.name, DEFAULT_CONFIG["default_strings"]["not_detected"])]
+            list(shell),
+            [(shell.name, None)],
         )
 
 

--- a/archey/test/entries/test_archey_shell.py
+++ b/archey/test/entries/test_archey_shell.py
@@ -59,10 +59,6 @@ class TestShellEntry(unittest.TestCase):
         """`id` fails, but Archey must not !"""
         shell = Shell()
         self.assertIsNone(shell.value)
-        self.assertListEqual(
-            list(shell),
-            [(shell.name, None)],
-        )
 
 
 if __name__ == "__main__":

--- a/archey/test/entries/test_archey_temperature.py
+++ b/archey/test/entries/test_archey_temperature.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import unittest
 from subprocess import CalledProcessError
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.temperature import Temperature
@@ -333,17 +333,13 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
         # pylint: enable=protected-access
 
     @HelperMethods.patch_clean_configuration
-    def test_output(self):
-        """Test `output` method"""
-        output_mock = MagicMock()
-
+    def test_pretty_value(self):
+        """Test `pretty_value` property"""
         # No value --> not detected.
-        Temperature.output(self.temperature_mock, output_mock)
-        self.assertEqual(
-            output_mock.append.call_args[0][1], DEFAULT_CONFIG["default_strings"]["not_detected"]
+        self.assertListEqual(
+            Temperature.pretty_value.__get__(self.temperature_mock),
+            [(self.temperature_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
         )
-
-        output_mock.reset_mock()
 
         # Values --> normal behavior.
         self.temperature_mock._temps = [50.0, 40.0, 50.0]  # pylint: disable=protected-access
@@ -353,8 +349,10 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
             "char_before_unit": "o",
             "unit": "C",
         }
-        Temperature.output(self.temperature_mock, output_mock)
-        self.assertEqual(output_mock.append.call_args[0][1], "46.7oC (Max. 50.0oC)")
+        self.assertListEqual(
+            Temperature.pretty_value.__get__(self.temperature_mock),
+            [(self.temperature_mock.name, "46.7oC (Max. 50.0oC)")],
+        )
 
         # Only one value --> no maximum.
         self.temperature_mock._temps = [42.8]  # pylint: disable=protected-access
@@ -364,8 +362,10 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
             "char_before_unit": " ",
             "unit": "C",
         }
-        Temperature.output(self.temperature_mock, output_mock)
-        self.assertEqual(output_mock.append.call_args[0][1], "42.8 C")
+        self.assertListEqual(
+            Temperature.pretty_value.__get__(self.temperature_mock),
+            [(self.temperature_mock.name, "42.8 C")],
+        )
 
     def test_convert_to_fahrenheit(self):
         """Simple tests for the `_convert_to_fahrenheit` static method"""

--- a/archey/test/entries/test_archey_temperature.py
+++ b/archey/test/entries/test_archey_temperature.py
@@ -6,7 +6,6 @@ import unittest
 from subprocess import CalledProcessError
 from unittest.mock import Mock, patch
 
-from archey.configuration import DEFAULT_CONFIG
 from archey.entries.temperature import Temperature
 from archey.test import CustomAssertions
 from archey.test.entries import HelperMethods
@@ -333,12 +332,12 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
         # pylint: enable=protected-access
 
     @HelperMethods.patch_clean_configuration
-    def test_pretty_value(self):
-        """Test `pretty_value` property"""
-        # No value --> not detected.
+    def test_output(self):
+        """Test output values"""
+        # No value --> `None`.
         self.assertListEqual(
-            Temperature.pretty_value.__get__(self.temperature_mock),
-            [(self.temperature_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
+            list(self.temperature_mock),
+            [(self.temperature_mock.name, None)],
         )
 
         # Values --> normal behavior.
@@ -350,7 +349,7 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
             "unit": "C",
         }
         self.assertListEqual(
-            Temperature.pretty_value.__get__(self.temperature_mock),
+            list(self.temperature_mock),
             [(self.temperature_mock.name, "46.7oC (Max. 50.0oC)")],
         )
 
@@ -363,7 +362,7 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
             "unit": "C",
         }
         self.assertListEqual(
-            Temperature.pretty_value.__get__(self.temperature_mock),
+            list(self.temperature_mock),
             [(self.temperature_mock.name, "42.8 C")],
         )
 

--- a/archey/test/entries/test_archey_temperature.py
+++ b/archey/test/entries/test_archey_temperature.py
@@ -335,10 +335,7 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
     def test_output(self):
         """Test output values"""
         # No value --> `None`.
-        self.assertListEqual(
-            list(self.temperature_mock),
-            [(self.temperature_mock.name, None)],
-        )
+        self.assertIsNone(self.temperature_mock.value)
 
         # Values --> normal behavior.
         self.temperature_mock._temps = [50.0, 40.0, 50.0]  # pylint: disable=protected-access
@@ -348,9 +345,9 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
             "char_before_unit": "o",
             "unit": "C",
         }
-        self.assertListEqual(
-            list(self.temperature_mock),
-            [(self.temperature_mock.name, "46.7oC (Max. 50.0oC)")],
+        self.assertEqual(
+            str(self.temperature_mock),
+            "46.7oC (Max. 50.0oC)",
         )
 
         # Only one value --> no maximum.
@@ -361,10 +358,7 @@ class TestTemperatureEntry(unittest.TestCase, CustomAssertions):
             "char_before_unit": " ",
             "unit": "C",
         }
-        self.assertListEqual(
-            list(self.temperature_mock),
-            [(self.temperature_mock.name, "42.8 C")],
-        )
+        self.assertEqual(str(self.temperature_mock), "42.8 C")
 
     def test_convert_to_fahrenheit(self):
         """Simple tests for the `_convert_to_fahrenheit` static method"""

--- a/archey/test/entries/test_archey_terminal.py
+++ b/archey/test/entries/test_archey_terminal.py
@@ -77,8 +77,8 @@ class TestTerminalEntry(unittest.TestCase):
         """Check that `TERM` is honored if present, and Unicode support for the colors palette"""
         terminal = Terminal(options={"use_unicode": True})
         self.assertEqual(terminal.value, "xterm-256color")
-        self.assertTrue(terminal.pretty_value[0][1].startswith("xterm-256color"))
-        self.assertEqual(terminal.pretty_value[0][1].count("\u2588"), 7 * 2)
+        self.assertTrue(str(terminal).startswith("xterm-256color"))
+        self.assertEqual(str(terminal).count("\u2588"), 7 * 2)
 
     @patch.dict(
         "archey.entries.terminal.os.environ",
@@ -111,7 +111,7 @@ class TestTerminalEntry(unittest.TestCase):
             terminal = Terminal()
 
             self.assertEqual(terminal.value, "X-TERMINAL-EMULATOR")
-            self.assertListEqual(terminal.pretty_value, [(terminal.name, "X-TERMINAL-EMULATOR")])
+            self.assertListEqual(list(terminal), [(terminal.name, "X-TERMINAL-EMULATOR")])
 
     @patch.dict(
         "archey.entries.terminal.os.environ",
@@ -123,12 +123,8 @@ class TestTerminalEntry(unittest.TestCase):
         """Test terminal emulator (non-)detection, without Unicode support"""
         terminal = Terminal(options={"use_unicode": False})
         self.assertIsNone(terminal.value)
-        self.assertTrue(
-            terminal.pretty_value[0][1].startswith(
-                DEFAULT_CONFIG["default_strings"]["not_detected"]
-            )
-        )
-        self.assertFalse(terminal.pretty_value[0][1].count("\u2588"))
+        self.assertTrue(str(terminal).startswith(DEFAULT_CONFIG["default_strings"]["not_detected"]))
+        self.assertFalse(str(terminal).count("\u2588"))
 
 
 if __name__ == "__main__":

--- a/archey/test/entries/test_archey_terminal.py
+++ b/archey/test/entries/test_archey_terminal.py
@@ -1,7 +1,7 @@
 """Test module for Archey's terminal detection module"""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.terminal import Terminal
@@ -76,13 +76,9 @@ class TestTerminalEntry(unittest.TestCase):
     def test_terminal_emulator_term_fallback_and_unicode(self):
         """Check that `TERM` is honored if present, and Unicode support for the colors palette"""
         terminal = Terminal(options={"use_unicode": True})
-
-        output_mock = MagicMock()
-        terminal.output(output_mock)
-
         self.assertEqual(terminal.value, "xterm-256color")
-        self.assertTrue(output_mock.append.call_args[0][1].startswith("xterm-256color"))
-        self.assertEqual(output_mock.append.call_args[0][1].count("\u2588"), 7 * 2)
+        self.assertTrue(terminal.pretty_value[0][1].startswith("xterm-256color"))
+        self.assertEqual(terminal.pretty_value[0][1].count("\u2588"), 7 * 2)
 
     @patch.dict(
         "archey.entries.terminal.os.environ",
@@ -114,11 +110,8 @@ class TestTerminalEntry(unittest.TestCase):
         with patch("archey.colors.Style.should_color_output", return_value=False):
             terminal = Terminal()
 
-            output_mock = MagicMock()
-            terminal.output(output_mock)
-
             self.assertEqual(terminal.value, "X-TERMINAL-EMULATOR")
-            self.assertEqual(output_mock.append.call_args[0][1], "X-TERMINAL-EMULATOR")
+            self.assertListEqual(terminal.pretty_value, [(terminal.name, "X-TERMINAL-EMULATOR")])
 
     @patch.dict(
         "archey.entries.terminal.os.environ",
@@ -129,14 +122,13 @@ class TestTerminalEntry(unittest.TestCase):
     def test_not_detected(self):
         """Test terminal emulator (non-)detection, without Unicode support"""
         terminal = Terminal(options={"use_unicode": False})
-
-        output_mock = MagicMock()
-        terminal.output(output_mock)
-        output = output_mock.append.call_args[0][1]
-
         self.assertIsNone(terminal.value)
-        self.assertTrue(output.startswith(DEFAULT_CONFIG["default_strings"]["not_detected"]))
-        self.assertFalse(output.count("\u2588"))
+        self.assertTrue(
+            terminal.pretty_value[0][1].startswith(
+                DEFAULT_CONFIG["default_strings"]["not_detected"]
+            )
+        )
+        self.assertFalse(terminal.pretty_value[0][1].count("\u2588"))
 
 
 if __name__ == "__main__":

--- a/archey/test/entries/test_archey_uptime.py
+++ b/archey/test/entries/test_archey_uptime.py
@@ -199,9 +199,9 @@ class TestUptimeEntry(unittest.TestCase):
                 "minutes": 1,
                 "seconds": 0,
             }
-            self.assertListEqual(
-                Uptime.pretty_value.__get__(uptime_instance_mock),
-                [(uptime_instance_mock.name, "2 hours and 1 minute")],
+            self.assertEqual(
+                str(uptime_instance_mock),
+                "2 hours and 1 minute",
             )
 
         with self.subTest("Output in case of days, hours and minutes."):
@@ -211,9 +211,9 @@ class TestUptimeEntry(unittest.TestCase):
                 "minutes": 2,
                 "seconds": 0,
             }
-            self.assertListEqual(
-                Uptime.pretty_value.__get__(uptime_instance_mock),
-                [(uptime_instance_mock.name, "1 day, 1 hour and 2 minutes")],
+            self.assertEqual(
+                str(uptime_instance_mock),
+                "1 day, 1 hour and 2 minutes",
             )
 
         with self.subTest("Output in case of days and minutes."):
@@ -223,9 +223,9 @@ class TestUptimeEntry(unittest.TestCase):
                 "minutes": 3,
                 "seconds": 0,
             }
-            self.assertListEqual(
-                Uptime.pretty_value.__get__(uptime_instance_mock),
-                [(uptime_instance_mock.name, "3 days and 3 minutes")],
+            self.assertEqual(
+                str(uptime_instance_mock),
+                "3 days and 3 minutes",
             )
 
         with self.subTest("Output in case of very early execution."):
@@ -235,9 +235,9 @@ class TestUptimeEntry(unittest.TestCase):
                 "minutes": 0,
                 "seconds": 0,
             }
-            self.assertListEqual(
-                Uptime.pretty_value.__get__(uptime_instance_mock),
-                [(uptime_instance_mock.name, "< 1 minute")],
+            self.assertEqual(
+                str(uptime_instance_mock),
+                "< 1 minute",
             )
 
 

--- a/archey/test/entries/test_archey_uptime.py
+++ b/archey/test/entries/test_archey_uptime.py
@@ -3,7 +3,7 @@
 import unittest
 from datetime import timedelta
 from itertools import product
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import mock_open, patch
 
 from archey.entries.uptime import Uptime
 from archey.exceptions import ArcheyException
@@ -191,7 +191,6 @@ class TestUptimeEntry(unittest.TestCase):
     def test_various_output_cases(self):
         """Test when the device has just been started..."""
         uptime_instance_mock = HelperMethods.entry_mock(Uptime)
-        output_mock = MagicMock()
 
         with self.subTest("Output in case of hours and minutes."):
             uptime_instance_mock.value = {
@@ -200,10 +199,10 @@ class TestUptimeEntry(unittest.TestCase):
                 "minutes": 1,
                 "seconds": 0,
             }
-            Uptime.output(uptime_instance_mock, output_mock)
-            self.assertEqual(output_mock.append.call_args[0][1], "2 hours and 1 minute")
-
-        output_mock.reset_mock()
+            self.assertListEqual(
+                Uptime.pretty_value.__get__(uptime_instance_mock),
+                [(uptime_instance_mock.name, "2 hours and 1 minute")],
+            )
 
         with self.subTest("Output in case of days, hours and minutes."):
             uptime_instance_mock.value = {
@@ -212,10 +211,10 @@ class TestUptimeEntry(unittest.TestCase):
                 "minutes": 2,
                 "seconds": 0,
             }
-            Uptime.output(uptime_instance_mock, output_mock)
-            self.assertEqual(output_mock.append.call_args[0][1], "1 day, 1 hour and 2 minutes")
-
-        output_mock.reset_mock()
+            self.assertListEqual(
+                Uptime.pretty_value.__get__(uptime_instance_mock),
+                [(uptime_instance_mock.name, "1 day, 1 hour and 2 minutes")],
+            )
 
         with self.subTest("Output in case of days and minutes."):
             uptime_instance_mock.value = {
@@ -224,10 +223,10 @@ class TestUptimeEntry(unittest.TestCase):
                 "minutes": 3,
                 "seconds": 0,
             }
-            Uptime.output(uptime_instance_mock, output_mock)
-            self.assertEqual(output_mock.append.call_args[0][1], "3 days and 3 minutes")
-
-        output_mock.reset_mock()
+            self.assertListEqual(
+                Uptime.pretty_value.__get__(uptime_instance_mock),
+                [(uptime_instance_mock.name, "3 days and 3 minutes")],
+            )
 
         with self.subTest("Output in case of very early execution."):
             uptime_instance_mock.value = {
@@ -236,8 +235,10 @@ class TestUptimeEntry(unittest.TestCase):
                 "minutes": 0,
                 "seconds": 0,
             }
-            Uptime.output(uptime_instance_mock, output_mock)
-            self.assertEqual(output_mock.append.call_args[0][1], "< 1 minute")
+            self.assertListEqual(
+                Uptime.pretty_value.__get__(uptime_instance_mock),
+                [(uptime_instance_mock.name, "< 1 minute")],
+            )
 
 
 if __name__ == "__main__":

--- a/archey/test/entries/test_archey_user.py
+++ b/archey/test/entries/test_archey_user.py
@@ -1,7 +1,7 @@
 """Test module for Archey's session user name detection module"""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.user import User
@@ -27,15 +27,12 @@ class TestUserEntry(unittest.TestCase):
         self.assertIsNone(User().value)
 
     @HelperMethods.patch_clean_configuration
-    def test_output(self):
-        """Simple test for `output` base method"""
+    def test_pretty_value(self):
+        """Simple test for `pretty_value` base property"""
         user_instance_mock = HelperMethods.entry_mock(User)
-
-        output_mock = MagicMock()
-        User.output(user_instance_mock, output_mock)
-
-        self.assertEqual(
-            output_mock.append.call_args[0][1], DEFAULT_CONFIG["default_strings"]["not_detected"]
+        self.assertListEqual(
+            User.pretty_value.__get__(user_instance_mock),
+            [(user_instance_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
         )
 
 

--- a/archey/test/entries/test_archey_user.py
+++ b/archey/test/entries/test_archey_user.py
@@ -3,9 +3,7 @@
 import unittest
 from unittest.mock import patch
 
-from archey.configuration import DEFAULT_CONFIG
 from archey.entries.user import User
-from archey.test.entries import HelperMethods
 
 
 class TestUserEntry(unittest.TestCase):
@@ -25,15 +23,6 @@ class TestUserEntry(unittest.TestCase):
         """Simple mock, simple test"""
         self.assertEqual(User().value, "USERNAME")
         self.assertIsNone(User().value)
-
-    @HelperMethods.patch_clean_configuration
-    def test_pretty_value(self):
-        """Simple test for `pretty_value` base property"""
-        user_instance_mock = HelperMethods.entry_mock(User)
-        self.assertListEqual(
-            User.pretty_value.__get__(user_instance_mock),
-            [(user_instance_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
-        )
 
 
 if __name__ == "__main__":

--- a/archey/test/entries/test_archey_wan_ip.py
+++ b/archey/test/entries/test_archey_wan_ip.py
@@ -116,16 +116,10 @@ class TestWanIPEntry(unittest.TestCase, CustomAssertions):
         """
         self.wan_ip_mock.value = ["XXX.YY.ZZ.TTT", "0123::4567:89a:dead:beef"]
 
-        with self.subTest("Single-line combined output."):
-            self.assertListEqual(
-                WanIP.pretty_value.__get__(self.wan_ip_mock),
-                [(self.wan_ip_mock.name, "XXX.YY.ZZ.TTT, 0123::4567:89a:dead:beef")],
-            )
-
-        with self.subTest("Multi-lines output."):
+        with self.subTest("Normal output."):
             self.wan_ip_mock.options["one_line"] = False
             self.assertListEqual(
-                WanIP.pretty_value.__get__(self.wan_ip_mock),
+                list(self.wan_ip_mock),
                 [
                     ("WAN IP", "XXX.YY.ZZ.TTT"),
                     ("WAN IP", "0123::4567:89a:dead:beef"),
@@ -138,8 +132,8 @@ class TestWanIPEntry(unittest.TestCase, CustomAssertions):
             self.wan_ip_mock.value = []
             self.assertListEmpty(self.wan_ip_mock.value)
             self.assertListEqual(
-                WanIP.pretty_value.__get__(self.wan_ip_mock),
-                [(self.wan_ip_mock.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
+                list(self.wan_ip_mock),
+                [],
             )
 
     @HelperMethods.patch_clean_configuration
@@ -151,7 +145,7 @@ class TestWanIPEntry(unittest.TestCase, CustomAssertions):
         self.wan_ip_mock.value = []
         self.assertListEmpty(self.wan_ip_mock.value)
         self.assertListEqual(
-            WanIP.pretty_value.__get__(self.wan_ip_mock),
+            list(self.wan_ip_mock),
             [(self.wan_ip_mock.name, DEFAULT_CONFIG["default_strings"]["no_address"])],
         )
 

--- a/archey/test/entries/test_archey_window_manager.py
+++ b/archey/test/entries/test_archey_window_manager.py
@@ -1,7 +1,7 @@
 """Test module for Archey's window manager detection module"""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from archey.configuration import DEFAULT_CONFIG
 from archey.entries.window_manager import WindowManager
@@ -74,13 +74,10 @@ Window manager's "showing the desktop" mode: OFF
     def test_no_wmctrl_mismatch(self, _, __):
         """Test (non-detection) when processes list do not contain any known value"""
         window_manager = WindowManager()
-
-        output_mock = MagicMock()
-        window_manager.output(output_mock)
-
         self.assertIsNone(window_manager.value["name"])
-        self.assertEqual(
-            output_mock.append.call_args[0][1], DEFAULT_CONFIG["default_strings"]["not_detected"]
+        self.assertListEqual(
+            window_manager.pretty_value,
+            [(window_manager.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
         )
 
 

--- a/archey/test/entries/test_archey_window_manager.py
+++ b/archey/test/entries/test_archey_window_manager.py
@@ -75,9 +75,9 @@ Window manager's "showing the desktop" mode: OFF
         """Test (non-detection) when processes list do not contain any known value"""
         window_manager = WindowManager()
         self.assertIsNone(window_manager.value["name"])
-        self.assertListEqual(
-            window_manager.pretty_value,
-            [(window_manager.name, DEFAULT_CONFIG["default_strings"]["not_detected"])],
+        self.assertEqual(
+            str(window_manager),
+            DEFAULT_CONFIG["default_strings"]["not_detected"],
         )
 
 

--- a/archey/test/test_archey_entry.py
+++ b/archey/test/test_archey_entry.py
@@ -13,9 +13,10 @@ class _SimpleEntry(Entry):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def output(self, output) -> None:
+    @property
+    def pretty_value(self) -> "typing.List[tuple[str, str]]":
         """Reverse order!"""
-        output.append((self.value, self.name))
+        return [(self.value, self.name)]
 
 
 class TestEntry(unittest.TestCase):
@@ -57,6 +58,4 @@ class TestEntry(unittest.TestCase):
     def test_entry_output_overriding(self):
         """Check `Entry.output` public method overriding"""
         simple_entry = _SimpleEntry("is this", "ordered")
-        output: typing.List[typing.Tuple[str, ...]] = []
-        simple_entry.output(output)
-        self.assertListEqual(output, [("ordered", "is this")])
+        self.assertListEqual(simple_entry.pretty_value, [("ordered", "is this")])

--- a/archey/test/test_archey_entry.py
+++ b/archey/test/test_archey_entry.py
@@ -14,7 +14,7 @@ class _SimpleEntry(Entry):
         super().__init__(*args, **kwargs)
 
     @property
-    def pretty_value(self) -> "typing.List[tuple[str, str]]":
+    def pretty_value(self) -> "typing.List[typing.Tuple[str, str]]":
         """Reverse order!"""
         return [(self.value, self.name)]
 


### PR DESCRIPTION
## Description
I mentioned this already in #146 - this approach is a "bit more OOP". I find it easier to reason about `output` getting the property directly from each entry than a callback (`output.output`) calling a callback (`entry.output`) calling a callback (`output.append`)!!


## Reason and / or context
Partly cleaner, partly because it makes it easier to cache these properties for #146 :grin: 


## How has this been tested ?
Seems to work alright on my system, unit tests updated accordingly


## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- ~~Bug fix (non-breaking change which fixes an issue)~~
- [X] Typo / style fix (non-breaking change which improves readability) -- I think? Unless someone is directly trying to access `Entry.output` I don't think there's any end-user difference
- ~~New feature (non-breaking change which adds functionality)~~
- ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- ~~\[IF NEEDED\] I have updated the _README.md_ file accordingly ;~~
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [?] \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
