### PR TITLE
Changes default Red Hat (rhel) logo to current logo "The hat"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project (partially) adheres to [Semantic Versioning](https://semver.org
 ### Added
 - Official EndeavourOS distribution support
 - Display server protocol to `WindowManager`
+- New Red Hat logo "The Hat"
 
 ### Changed
 - Allow `df` output to contain Unicode characters
 - Extend logos consistency test case to all logo styles
 - `WindowManager` API value format: now an object with `name` and `display_server_protocol` attributes
+- Old Red Hat logo is available as alternate logo `shadowman`
 
 ## [v4.14.2.0] - 2023-08-26
 ### Added

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -28,6 +28,7 @@ See <https://www.gnu.org/licenses/gpl-3.0.txt> for the full license text.
 * Elementary OS proper ASCII logo integration by @SomethingGeneric <mcompton2002@gmail.com>
 * Pop!\_OS proper ASCII logo integration by @airvue
 * Project logo by Brume <contact@brume.ink>
+* Red Hat logo "The hat" by @helmchen
 
 ## Maintainers
 

--- a/archey/logos/rhel.py
+++ b/archey/logos/rhel.py
@@ -2,9 +2,39 @@
 
 from archey.colors import Colors
 
-COLORS = [Colors.RED_BRIGHT, Colors.WHITE_BRIGHT, Colors.RED_NORMAL]
+COLORS = [Colors.RED_BRIGHT, Colors.WHITE_BRIGHT]
 
 LOGO = [
+    """{c[0]}            .MM:..:MMMMMMM.               """,
+    """{c[0]}           MMMMMMMMMMMMMMMMMM             """,
+    """{c[0]}           MMMMMMMMMMMMMMMMMMMM.          """,
+    """{c[0]}          MMMMMMMMMMMMMMMMMMMMMM          """,
+    """{c[0]}         ,MMMMMMMMMMMMMMMMMMMMMM:         """,
+    """{c[0]}         MMMMMMMMMMMMMMMMMMMMMMMM         """,
+    """{c[0]}   .MMMM'  MMMMMMMMMMMMMMMMMMMMMM         """,
+    """{c[0]} MMMMMM    `MMMMMMMMMMMMMMMMMMMM.         """,
+    """{c[0]} MMMMMMMM      MMMMMMMMMMMMMMMMMM .       """,
+    """{c[0]} MMMMMMMMM.       `MMMMMMMMMMMMM' MM.     """,
+    """{c[0]} `MMMMMMMMMMMMM.        `""`     ,MMMMM.  """,
+    """{c[0]} `MMMMMMMMMMMMMMMMM:.         .:MMMMMMMM. """,
+    """{c[0]}     MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM """,
+    """{c[0]}       MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM: """,
+    """{c[0]}          MMMMMMMMMMMMMMMMMMMMMMMMMMMMMM  """,
+    """{c[0]}             `MMMMMMMMMMMMMMMMMMMMMMMM:   """,
+    """{c[0]}                 ``MMMMMMMMMMMMMMMMM'     """,
+    """{c[0]}                           `""`           """,
+    """{c[1]}              R e d   H a t               """,
+]
+
+# Alias to the current logo "the hat"
+COLORS_HAT = COLORS
+LOGO_HAT = LOGO
+
+
+# Alternative logo : "Shadowman" (tho old logo).
+COLORS_SHADOWMAN = [Colors.RED_BRIGHT, Colors.WHITE_BRIGHT, Colors.RED_NORMAL]
+
+LOGO_SHADOWMAN = [
     """{c[0]}              {c[2]}\\`.-..........\\`{c[0]}            """,
     """{c[0]}             {c[2]}\\`////////::.\\`-/.{c[0]}           """,
     """{c[0]}             {c[2]}-: ....-////////.{c[0]}            """,


### PR DESCRIPTION
The default logo for RHEL has been changed to the new logo "the hat". The previous logo is sill available as alternate logo `shadowman` 


## Description
- Implementation of the the new logo
- renaming the previous logo to LOGO_SHADOWMAN
- Providing alias for the current logo as LOGO_HAT


## Reason and / or context
Cosmetic reasoons :-)


## How has this been tested ?
Visually tested using following commands:

python3 -m archey -d rhel 
python3 -m archey -d rhel -l shadow man

on a Mac (macOS 13.6.3 x86_64; Darwin 22.6.0) from macOS terminal as well as from inside VSCode.


## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Typo / style fix (non-breaking change which improves readability)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [ ] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [ ] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- [ ] \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
