### PR TITLE
[GPU] Parses `lspci` to avoid classing 3D NAND devices as GPUs.

### DIFF
--- a/archey/test/entries/test_archey_gpu.py
+++ b/archey/test/entries/test_archey_gpu.py
@@ -17,18 +17,25 @@ class TestGPUEntry(unittest.TestCase, CustomAssertions):
         side_effect=[
             FileNotFoundError(),
             """\
-XX:YY.H IDE interface: IIIIIIIIIIIIIIII
-XX:YY.H SMBus: BBBBBBBBBBBBBBBB
-XX:YY.H VGA compatible controller: GPU-MODEL-NAME
-XX:YY.H Audio device: DDDDDDDDDDDDDDDD
+XX:YY.H "IDE interface" "Manufacturer" "IIIIIIIIIIIIIIII"
+XX:YY.H "SMBus" "Manufacturer" "BBBBBBBBBBBBBBBB"
+XX:YY.H "VGA compatible controller" "GPU-Manufacturer" "GPU-MODEL-NAME"
+XX:YY.H "Audio device" "Manufacturer" "DDDDDDDDDDDDDDDD"
 """,
             """\
-XX:YY.H IDE interface: IIIIIIIIIIIIIIII
-XX:YY.H SMBus: BBBBBBBBBBBBBBBB
-XX:YY.H VGA compatible controller: GPU-MODEL-NAME
-XX:YY.H Display controller: ANOTHER-MATCHING-VIDEO-CONTROLLER
-XX:YY.H Audio device: DDDDDDDDDDDDDDDD
-XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
+XX:YY.H "IDE interface" "Manufacturer" "IIIIIIIIIIIIIIII"
+XX:YY.H "SMBus" "Manufacturer" "BBBBBBBBBBBBBBBB"
+XX:YY.H "VGA compatible controller" "GPU-Manufacturer" "GPU-MODEL-NAME"
+XX:YY.H "Display controller" "Another-GPU-Manufacturer" "ANOTHER-MATCHING-VIDEO-CONTROLLER"
+XX:YY.H "Audio device" "Manufacturer" "DDDDDDDDDDDDDDDD"
+XX:YY.H "3D controller" "3D-Manufacturer" "3D GPU-MODEL-NAME TAKES ADVANTAGE"
+""",
+            """\
+XX:YY.H "IDE interface" "Manufacturer" "IIIIIIIIIIIIIIII"
+XX:YY.H "SMBus" "Manufacturer" "BBBBBBBBBBBBBBBB"
+XX:YY.H "VGA compatible controller" "GPU-Manufacturer" "GPU-MODEL-NAME"
+XX:YY.H "Audio device" "Manufacturer" "DDDDDDDDDDDDDDDD"
+XX:YY.H "Non-Volatile memory controller" "Sandisk Corp" "SanDisk Ultra 3D / WD Blue SN570 NVMe SSD"
 """,
         ],
     )
@@ -36,15 +43,17 @@ XX:YY.H 3D controller: 3D GPU-MODEL-NAME TAKES ADVANTAGE
         """Check `_parse_lspci_output` behavior"""
         # pylint: disable=protected-access
         self.assertListEmpty(GPU._parse_lspci_output())
-        self.assertListEqual(GPU._parse_lspci_output(), ["GPU-MODEL-NAME"])
+        self.assertListEqual(GPU._parse_lspci_output(), ["GPU-Manufacturer GPU-MODEL-NAME"])
         self.assertListEqual(
             GPU._parse_lspci_output(),
             [
-                "3D GPU-MODEL-NAME TAKES ADVANTAGE",
-                "GPU-MODEL-NAME",
-                "ANOTHER-MATCHING-VIDEO-CONTROLLER",
+                "3D-Manufacturer 3D GPU-MODEL-NAME TAKES ADVANTAGE",
+                "GPU-Manufacturer GPU-MODEL-NAME",
+                "Another-GPU-Manufacturer ANOTHER-MATCHING-VIDEO-CONTROLLER",
             ],
         )
+        # Ensure 3D nand flash is ignored; see issue #149
+        self.assertListEqual(GPU._parse_lspci_output(), ["GPU-Manufacturer GPU-MODEL-NAME"])
         # pylint: enable=protected-access
 
     @patch(


### PR DESCRIPTION
Fix for #149.

## Description
Parse `lspci -m` (ie machine readable format) to only match on the PCI class rather than the entire vendor + product string.

## Reason and / or context
See #149 :grin: 

## How has this been tested ?
Seems to work fine on my systems, modified tests pass.

## Types of changes :
- [X] Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [X] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
