### PR TITLE
[ENTRIES] Implements `hide_undetected` option to mask missing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project (partially) adheres to [Semantic Versioning](https://semver.org
 ### Added
 - Python 3.13 & 3.14 official support
 - `entries_color` config option validation
+- `hide_undetected` config option to hide undetected entries
+
+### Changed
+- `Entry` behavior in boolean contexts ("truthy" when `value` is populated)
 
 ## [v4.15.0.0] - 2024-09-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ Below stand further descriptions for each available (default) option :
 	// Note that the `--logo-style` argument overrides this setting.
 	"logo_style": "",
 	//
+	// Use this option to hide undetected entries, to prevent "Not detected" messages from being displayed.
+	"hide_undetected": false,
+	//
 	// Enable icons for entries.
 	// A terminal "nerd font" is required to display the icons. Otherwise, these are simply missing and a placeholder will be seen.
 	// You can also refer to : <https://github.com/ryanoasis/nerd-fonts>.

--- a/archey/__main__.py
+++ b/archey/__main__.py
@@ -184,7 +184,7 @@ def main():
             mapper = executor.map
 
         for entry_instance in mapper(_entry_instantiator, available_entries):
-            if entry_instance:
+            if entry_instance is not None:
                 output.add_entry(entry_instance)
 
     output.output()

--- a/archey/entry.py
+++ b/archey/entry.py
@@ -44,6 +44,9 @@ class Entry(AbstractBaseClass):
         # Provision a logger for each entry.
         self._logger = logging.getLogger(self.__module__)
 
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
     def output(self, output) -> None:
         """Output the results to output. Can be overridden by subclasses."""
         if self.value:

--- a/archey/test/test_archey_entry.py
+++ b/archey/test/test_archey_entry.py
@@ -30,7 +30,7 @@ class TestEntry(unittest.TestCase):
     def test_entry_disabling(self):
         """Test `Entry` _disabling_"""
         simple_entry = _SimpleEntry()
-        self.assertTrue(simple_entry)
+        self.assertIsNotNone(simple_entry)
 
         simple_entry = _SimpleEntry(options={"disabled": True})
         self.assertIsNone(simple_entry)
@@ -44,6 +44,7 @@ class TestEntry(unittest.TestCase):
         simple_entry = _SimpleEntry()
         self.assertEqual(simple_entry.name, "Simple Entry")
         self.assertIsNone(simple_entry.value)
+        self.assertFalse(simple_entry)
 
         # No `_PRETTY_NAME` is defined : proper fall-back on entry internal name.
         delattr(_SimpleEntry, "_PRETTY_NAME")
@@ -53,6 +54,7 @@ class TestEntry(unittest.TestCase):
         simple_entry = _SimpleEntry("T", "est")
         self.assertEqual(simple_entry.name, "T")
         self.assertEqual(simple_entry.value, "est")
+        self.assertTrue(simple_entry)
 
     def test_entry_output_overriding(self):
         """Check `Entry.output` public method overriding"""

--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
 	"entries_color": "",
 	"honor_ansi_color": true,
 	"logo_style": "",
+	"hide_undetected": false,
 	"entries_icon": false,
 	"entries": [
 		{ "type": "User" },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->


## Description
<!--- Describe your changes in detail -->
This patch adds a new configuration option to allow hiding "undetected entries".

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
This was wandering in my head for a while now. I guess minimal systems users (with a lot of empty values) may love this option (as this would allow them not to manually adapt `entries` object to remove unnecessary items).

## How has this been tested ?
<!--- Include details of your testing environment here -->
Unit tests + locally.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
-  Bug fix (non-breaking change which fixes an issue)
- [x] Typo / style fix (non-breaking change which improves readability)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

(partially breaking from an API point of view as `__bool__` magic method `Entry` definition cause objects to behave differently in boolean contexts/operations)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- [x] \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- [x] \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- \[IF BREAKING\] This pull request targets next Archey version branch ;
- [x] My changes looks good ;
- [x] I agree that my code may be modified in the future ;
- [x] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
