### PR TITLE
fix(disk): don't crash against non-UTF8 filesystems

### DIFF
--- a/archey/entries/disk.py
+++ b/archey/entries/disk.py
@@ -185,6 +185,7 @@ class Disk(Entry):
                 stderr=DEVNULL,
                 check=False,
                 encoding="utf-8",
+                errors="backslashreplace",
             ).stdout
         except OSError:
             # `df` isn't available on this system.

--- a/archey/output.py
+++ b/archey/output.py
@@ -183,9 +183,7 @@ class Output:  # pylint: disable=too-many-instance-attributes
         try:
             print(logo_with_entries.format(c=self._colors) + str(Colors.CLEAR))
         except UnicodeError as unicode_error:
-            raise ArcheyException(
-                """\
+            raise ArcheyException("""\
 Your locale or TTY does not seem to support UTF-8 encoding.
 Please disable Unicode within your configuration file.\
-"""
-            ) from unicode_error
+""") from unicode_error

--- a/archey/test/entries/test_archey_cpu.py
+++ b/archey/test/entries/test_archey_cpu.py
@@ -17,16 +17,14 @@ class TestCPUEntry(unittest.TestCase, CustomAssertions):
 
     @patch(
         "archey.entries.cpu.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 processor\t: 0
 vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
 model\t\t: YY
 model name\t: CPU-MODEL-NAME
 physical id\t: 0
-"""
-        ),
+"""),
     )
     def test_parse_proc_cpuinfo_one_entry(self):
         """Test `/proc/cpuinfo` parsing"""
@@ -37,8 +35,7 @@ physical id\t: 0
 
     @patch(
         "archey.entries.cpu.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 processor\t: 0
 vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
@@ -59,8 +56,7 @@ cpu family\t: X
 model\t\t: YY
 model name\t: ANOTHER-CPU-MODEL
 physical id\t: 1
-"""
-        ),
+"""),
     )
     def test_parse_proc_cpuinfo_multiple_entries(self):
         """Test `/proc/cpuinfo` parsing"""
@@ -71,8 +67,7 @@ physical id\t: 1
 
     @patch(
         "archey.entries.cpu.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 processor\t: 0
 vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
@@ -100,8 +95,7 @@ cpu family\t: X
 model\t\t: YY
 model name\t: CPU-MODEL-NAME
 physical id\t: 1
-"""
-        ),
+"""),
     )
     def test_parse_proc_cpuinfo_one_cpu_dual_socket(self):
         """Test `/proc/cpuinfo` parsing for same CPU model across two sockets"""
@@ -112,8 +106,7 @@ physical id\t: 1
 
     @patch(
         "archey.entries.cpu.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 processor\t: 0
 vendor_id\t: CPU-VENDOR-NAME
 cpu family\t: X
@@ -141,8 +134,7 @@ cpu family\t: X
 model\t\t: YY
 model name\t: ANOTHER\tCPU   MODEL WITH STRANGE S P  A   C     E     S
 physical id\t: 1
-"""
-        ),
+"""),
     )
     def test_parse_proc_cpuinfo_multiple_inconsistent_entries(self):
         """

--- a/archey/test/entries/test_archey_desktop_environment.py
+++ b/archey/test/entries/test_archey_desktop_environment.py
@@ -111,8 +111,7 @@ class TestDesktopEnvironmentEntry(unittest.TestCase):
     )
     @patch(
         "archey.entries.desktop_environment.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 [Desktop Entry]
 Name=Retro Home
 Comment=Your home for retro gaming
@@ -122,8 +121,7 @@ Type=Application
 DesktopNames=Retro-Home;Ludo;
 
 no-value-option
-"""
-        ),
+"""),
     )
     def test_environment_detection_4_desktop_file(self, _) -> None:
         """_environment_detection against legacy `SESSION_DESKTOP` pointing to a desktop file"""
@@ -147,8 +145,7 @@ no-value-option
     )
     @patch(
         "archey.entries.desktop_environment.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 [Desktop Entry]
 Name=EmacsDesktop
 Comment=EmacsDesktop
@@ -159,8 +156,7 @@ X-LightDM-DesktopName=EmacsDesktop
 
 [Desktop Entry]
 Comment="Just messing with ConfigParser by adding section and option duplicates"
-"""
-        ),
+"""),
     )
     def test_environment_detection_4_desktop_file_fallback(self, _) -> None:
         """_environment_detection against legacy `SESSION_DESKTOP` pointing to a desktop file"""
@@ -184,12 +180,10 @@ Comment="Just messing with ConfigParser by adding section and option duplicates"
     )
     @patch(
         "archey.entries.desktop_environment.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 [Desktop Entry]
 Name=FooDesktop
-"""
-        ),
+"""),
     )
     def test_environment_detection_4_bad_desktop_file(self, _) -> None:
         """_environment_detection against legacy `SESSION_DESKTOP` pointing to a desktop file"""

--- a/archey/test/entries/test_archey_gpu.py
+++ b/archey/test/entries/test_archey_gpu.py
@@ -91,15 +91,13 @@ XX:YY.H "Non-Volatile memory controller" "Sandisk Corp" "SanDisk Ultra 3D / WD B
             (debugfs_dri_0 / "name").write_text(
                 "vc4 dev=XXXX:YY:ZZ.T master=pci:XXXX:YY:ZZ.T unique=XXXX:YY:ZZ.T\n"
             )
-            (debugfs_dri_0 / "v3d_ident").write_text(
-                """\
+            (debugfs_dri_0 / "v3d_ident").write_text("""\
 Revision:   1
 Slices:     3
 TMUs:       6
 QPUs:       12
 Semaphores: 16
-"""
-            )
+""")
             self.assertListEqual(
                 gpu_instance_mock._videocore_chipsets(gpu_instance_mock), ["VideoCore IV"]
             )
@@ -108,8 +106,7 @@ Semaphores: 16
             (debugfs_dri_0 / "name").write_text(
                 "v3d dev=XXXX:YY:ZZ.T master=pci:XXXX:YY:ZZ.T unique=XXXX:YY:ZZ.T\n"
             )
-            (debugfs_dri_0 / "v3d_ident").write_text(
-                """\
+            (debugfs_dri_0 / "v3d_ident").write_text("""\
 Revision:   4.2.14.0
 MMU:        yes
 TFU:        yes
@@ -124,8 +121,7 @@ Core 0:
   Semaphores:   0
   BCG int:      0
   Override TMU: 0
-"""
-            )
+""")
             self.assertListEqual(
                 gpu_instance_mock._videocore_chipsets(gpu_instance_mock), ["VideoCore VI"]
             )
@@ -134,8 +130,7 @@ Core 0:
             (debugfs_dri_0 / "name").write_text(
                 "v3d dev=XXXX:YY:ZZ.T master=pci:XXXX:YY:ZZ.T unique=XXXX:YY:ZZ.T\n"
             )
-            (debugfs_dri_0 / "v3d_ident").write_text(
-                """\
+            (debugfs_dri_0 / "v3d_ident").write_text("""\
 Revision:   7.1.7.0
 MMU:        yes
 TFU:        no
@@ -147,8 +142,7 @@ Core 0:
   TMUs:         4
   QPUs:         16
   Semaphores:   0
-"""
-            )
+""")
             self.assertListEqual(
                 gpu_instance_mock._videocore_chipsets(gpu_instance_mock), ["VideoCore VII"]
             )

--- a/archey/test/entries/test_archey_hostname.py
+++ b/archey/test/entries/test_archey_hostname.py
@@ -11,11 +11,9 @@ class TestHostnameEntry(unittest.TestCase):
 
     @patch(
         "archey.entries.hostname.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 MY-COOL-LAPTOP
-"""
-        ),
+"""),
     )
     def test_etc_hostname(self):
         """Mock reading from `/etc/hostname`"""

--- a/archey/test/entries/test_archey_ram.py
+++ b/archey/test/entries/test_archey_ram.py
@@ -32,8 +32,7 @@ Swap:          4095          39        4056
 
     @patch(
         "archey.entries.ram.open",
-        mock_open(
-            read_data="""\
+        mock_open(read_data="""\
 MemTotal:        7581000 kB
 MemFree:          716668 kB
 MemAvailable:    3632244 kB
@@ -58,8 +57,7 @@ Shmem:            451056 kB
 Slab:             314100 kB
 SReclaimable:     200792 kB
 SUnreclaim:       113308 kB
-"""
-        ),
+"""),
     )  # Some lines have been ignored as they are useless for computations.
     def test_read_proc_meminfo(self):
         """Test `_read_proc_meminfo` content parsing"""
@@ -108,13 +106,11 @@ Swapouts:                               3456015.
 
     @patch(
         "archey.entries.ram.check_output",
-        side_effect=[
-            """\
+        side_effect=["""\
 3992309
 3050620
 297854
-"""
-        ],
+"""],
     )
     @patch(
         "archey.entries.ram.os.sysconf",

--- a/archey/test/test_archey_configuration.py
+++ b/archey/test/test_archey_configuration.py
@@ -69,8 +69,7 @@ class TestConfiguration(unittest.TestCase):
             with open(
                 os.path.join(temp_dir, "config.json"), mode="w", encoding="UTF-8"
             ) as f_config:
-                f_config.write(
-                    """\
+                f_config.write("""\
 {
     "allow_overriding": false,
     "suppress_warnings": true,
@@ -84,8 +83,7 @@ class TestConfiguration(unittest.TestCase):
         "use_fahrenheit": true
     }
 }
-"""
-                )
+""")
 
             # Let's load it into our `Configuration` instance.
             configuration._load_configuration(temp_dir)  # pylint: disable=protected-access
@@ -177,8 +175,7 @@ class TestConfiguration(unittest.TestCase):
             # We create a fake temporary configuration file.
             config_file = os.path.join(temp_dir, "user.cfg")  # A pure arbitrary name.
             with open(config_file, mode="w", encoding="UTF-8") as f_config:
-                f_config.write(
-                    """\
+                f_config.write("""\
 {
     "allow_overriding": false,
     "suppress_warnings": true,
@@ -192,8 +189,7 @@ class TestConfiguration(unittest.TestCase):
         "use_fahrenheit": true
     }
 }
-"""
-                )
+""")
 
             configuration = Configuration(config_path=config_file)
 

--- a/archey/test/test_archey_output.py
+++ b/archey/test/test_archey_output.py
@@ -210,8 +210,7 @@ class TestOutput(unittest.TestCase):
                 "21",
             ]
             output.output()
-            print_mock.assert_called_with(
-                """\
+            print_mock.assert_called_with("""\
 FAKE_COLOR    1
     2
     3
@@ -233,8 +232,7 @@ FAKE_COLOR    1
     19
 FAKE_COLOR    20
 FAKE_COLOR    21\x1b[0m\
-"""
-            )
+""")
 
         output = Output()
 
@@ -296,8 +294,7 @@ FAKE_COLOR    21\x1b[0m\
                 "22",
             ]
             output.output()
-            print_mock.assert_called_with(
-                """\
+            print_mock.assert_called_with("""\
 FAKE_COLOR    1
 FAKE_COLOR    2
     3
@@ -320,8 +317,7 @@ FAKE_COLOR    2
     20
 FAKE_COLOR    21
 FAKE_COLOR    22\x1b[0m\
-"""
-            )
+""")
 
         output = Output()
 
@@ -438,15 +434,13 @@ FAKE_COLOR    22\x1b[0m\
         ]
         output.output()
 
-        print_mock.assert_called_with(
-            """\
+        print_mock.assert_called_with("""\
 W    short
 O    \x1b[0m...
 O    adjusted
 O    \x1b[0;31mshort\x1b[0m
 O    \x1b[0;31m\x1b[0m...\x1b[0m\
-"""
-        )
+""")
         # Check that `print` has been called only once.
         self.assertTrue(print_mock.assert_called_once)
 
@@ -507,13 +501,11 @@ O    \x1b[0;31m\x1b[0m...\x1b[0m\
         ]
         output.output()
 
-        print_mock.assert_called_with(
-            """\
+        print_mock.assert_called_with("""\
 entry_1
 entry_2
 entry_3\x1b[0m\
-"""
-        )
+""")
         # Check that `print` has been called only once.
         self.assertTrue(print_mock.assert_called_once)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When decoding filesystem names, replace non-UTF8 bytes by their escaped hexadecimal value.

## Reason and / or context
<!--- Why is this change required ? What problem does it solve ? -->
<!--- If it fixes an open issue, please link to the issue here -->
See #170.

## How has this been tested ?
<!--- Include details of your testing environment here -->
See #170.

## Types of changes :
<!--- What types of changes does your code introduce ? Put an `X` in all the boxes that apply : -->
- [X] Bug fix (non-breaking change which fixes an issue)
- Typo / style fix (non-breaking change which improves readability)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist :
<!--- Put an `X` in all the boxes that apply : -->
- \[IF NEEDED\] I have updated the _README.md_ file accordingly ;
- \[IF NEEDED\] I have updated the test cases (which pass) accordingly ;
- \[IF BREAKING\] This pull request targets next Archey version branch ;
- [X] My changes looks good ;
- [X] I agree that my code may be modified in the future ;
- [X] My code follows the code style of this project ([PEP8](https://www.python.org/dev/peps/pep-0008/)).
